### PR TITLE
랜딩 페이지 UI 작업

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "trailingComma": "es5",
   "printWidth": 100,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
+    "clsx": "^2.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.14.0",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clsx": "^2.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-icons": "^5.6.0",
     "react-router": "^7.14.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
+      react-icons:
+        specifier: ^5.6.0
+        version: 5.6.0(react@19.2.5)
       react-router:
         specifier: ^7.14.0
         version: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1131,6 +1134,11 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
 
   react-router@7.14.0:
     resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
@@ -2322,6 +2330,10 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-icons@5.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   react-router@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@8.0.7(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.8.3))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^19.2.4
         version: 19.2.5
@@ -20,6 +23,9 @@ importers:
       react-router:
         specifier: ^7.14.0
         version: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -640,6 +646,10 @@ packages:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1218,6 +1228,9 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -1895,6 +1908,8 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.0
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2402,6 +2417,8 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Route, Routes } from 'react-router';
-import LandingPage from './pages/LandingPage';
-import MainPage from './pages/MainPage';
-import CreatePage from './pages/CreatePage';
+import LandingPage from '@/pages/LandingPage';
+import MainPage from '@/pages/MainPage';
+import CreatePage from '@/pages/CreatePage';
 
 function App() {
   return (

--- a/src/components/landing/AppMockup.tsx
+++ b/src/components/landing/AppMockup.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/shared/cn';
+
 const NAV_ITEMS = ['아이디어', '기획서', '유저 시나리오', 'API 명세서'];
 
 const SKELETON_ROWS = [
@@ -37,12 +39,9 @@ export default function AppMockup() {
 
           {/* Nav items */}
           {NAV_ITEMS.map((item, i) => (
-            <div
-              key={item}
-              className={`rounded-md px-2 py-1.5 ${i === 0 ? 'bg-primary-light' : ''}`}
-            >
+            <div key={item} className={cn('rounded-md px-2 py-1.5', i === 0 && 'bg-primary-light')}>
               <span
-                className={`text-xs font-semibold ${i === 0 ? 'text-primary-dark' : 'text-ink'}`}
+                className={cn('text-xs font-semibold', i === 0 ? 'text-primary-dark' : 'text-ink')}
               >
                 {item}
               </span>
@@ -63,7 +62,7 @@ export default function AppMockup() {
           {/* Skeleton content */}
           <div className="flex flex-col gap-2.5">
             {SKELETON_ROWS.map(({ opacity, width }, i) => (
-              <div key={i} className={`h-3 rounded bg-border ${opacity} ${width}`} />
+              <div key={i} className={cn('h-3 rounded bg-border', opacity, width)} />
             ))}
           </div>
         </main>

--- a/src/components/landing/AppMockup.tsx
+++ b/src/components/landing/AppMockup.tsx
@@ -1,3 +1,4 @@
+import { MdAutoAwesome } from 'react-icons/md';
 import { cn } from '@/shared/cn';
 
 const NAV_ITEMS = ['아이디어', '기획서', '유저 시나리오', 'API 명세서'];
@@ -55,7 +56,7 @@ export default function AppMockup() {
           <div className="mb-5 flex items-center gap-3">
             <h3 className="text-2xl font-bold text-ink">아이디어</h3>
             <span className="rounded-md bg-ai-bg px-2 py-1 text-xs font-semibold text-ai">
-              ✦ AI 피드백
+              <MdAutoAwesome className="inline" /> AI 피드백
             </span>
           </div>
 

--- a/src/components/landing/AppMockup.tsx
+++ b/src/components/landing/AppMockup.tsx
@@ -1,0 +1,73 @@
+const NAV_ITEMS = ['아이디어', '기획서', '유저 시나리오', 'API 명세서'];
+
+const SKELETON_ROWS = [
+  { opacity: 'opacity-40', width: 'w-full' },
+  { opacity: 'opacity-30', width: 'w-4/5' },
+  { opacity: 'opacity-30', width: 'w-5/6' },
+  { opacity: 'opacity-20', width: 'w-2/3' },
+  { opacity: 'opacity-20', width: 'w-3/4' },
+];
+
+export default function AppMockup() {
+  return (
+    <div className="mx-auto w-full max-w-4xl overflow-hidden rounded-xl border border-border text-left shadow-2xl">
+      {/* Browser chrome */}
+      <div className="flex items-center gap-3 border-b border-border bg-surface px-4 py-3">
+        <div className="flex gap-1.5">
+          <div className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+          <div className="h-3 w-3 rounded-full bg-[#febc2e]" />
+          <div className="h-3 w-3 rounded-full bg-[#28c840]" />
+        </div>
+        <div className="mx-auto max-w-48 flex-1 rounded border border-border bg-white px-3 py-1 text-center text-xs text-ink-muted">
+          aidea.app/workspace
+        </div>
+      </div>
+
+      {/* App shell */}
+      <div className="flex h-72 bg-white">
+        {/* Sidebar */}
+        <aside className="flex w-40 flex-col gap-0.5 border-r border-border bg-sidebar p-3">
+          {/* Workspace */}
+          <div className="mb-2 flex items-center gap-2 px-2 py-1.5">
+            <div className="flex h-5 w-5 items-center justify-center rounded bg-primary">
+              <span className="text-xs font-bold text-white">G</span>
+            </div>
+            <span className="text-sm font-semibold text-ink">팀 스페이스</span>
+          </div>
+
+          {/* Nav items */}
+          {NAV_ITEMS.map((item, i) => (
+            <div
+              key={item}
+              className={`rounded-md px-2 py-1.5 ${i === 0 ? 'bg-primary-light' : ''}`}
+            >
+              <span
+                className={`text-xs font-semibold ${i === 0 ? 'text-primary-dark' : 'text-ink'}`}
+              >
+                {item}
+              </span>
+            </div>
+          ))}
+        </aside>
+
+        {/* Main content */}
+        <main className="flex-1 overflow-hidden p-8">
+          {/* Header */}
+          <div className="mb-5 flex items-center gap-3">
+            <h3 className="text-2xl font-bold text-ink">아이디어</h3>
+            <span className="rounded-md bg-ai-bg px-2 py-1 text-xs font-semibold text-ai">
+              ✦ AI 피드백
+            </span>
+          </div>
+
+          {/* Skeleton content */}
+          <div className="flex flex-col gap-2.5">
+            {SKELETON_ROWS.map(({ opacity, width }, i) => (
+              <div key={i} className={`h-3 rounded bg-border ${opacity} ${width}`} />
+            ))}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/CTASection.tsx
+++ b/src/components/landing/CTASection.tsx
@@ -1,0 +1,19 @@
+import Button from '@/components/ui/Button';
+
+export default function CTASection() {
+  return (
+    <section className="bg-ink px-6 py-24 text-center">
+      <div className="mx-auto max-w-2xl">
+        <h2 className="mb-4 text-4xl font-bold text-white">지금 바로 기획을 시작하세요</h2>
+        <p className="mb-8 leading-relaxed text-white/60" style={{ fontSize: '1rem' }}>
+          아이디어가 있다면 충분합니다. AI가 나머지를 함께 완성해드립니다.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <Button size="lg" className="bg-primary text-white hover:bg-primary-dark">
+            무료로 시작하기
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/FeaturesSection.tsx
+++ b/src/components/landing/FeaturesSection.tsx
@@ -1,7 +1,9 @@
+import type { ComponentType } from 'react';
+import { MdAutoAwesome, MdGroups, MdGridView, MdCode, MdRateReview } from 'react-icons/md';
 import { cn } from '@/shared/cn';
 
 interface Feature {
-  icon: string;
+  Icon: ComponentType<{ size?: number }>;
   iconBg: string;
   iconColor: string;
   title: string;
@@ -10,7 +12,7 @@ interface Feature {
 
 const FEATURES: Feature[] = [
   {
-    icon: '✦',
+    Icon: MdAutoAwesome,
     iconBg: 'bg-ai-bg',
     iconColor: 'text-ai',
     title: 'AI 기획 문서 자동 생성',
@@ -18,7 +20,7 @@ const FEATURES: Feature[] = [
       '핵심 아이디어만 입력하면 AI가 유저 시나리오, 기능 명세 초안을 자동으로 작성합니다. 논리적 허점까지 짚어드립니다.',
   },
   {
-    icon: '⌖',
+    Icon: MdGroups,
     iconBg: 'bg-primary-light',
     iconColor: 'text-primary-dark',
     title: '실시간 팀 협업',
@@ -26,7 +28,7 @@ const FEATURES: Feature[] = [
       'Figma처럼 팀원들의 커서와 작업 현황을 실시간으로 확인하며 함께 문서를 완성합니다.',
   },
   {
-    icon: '▤',
+    Icon: MdGridView,
     iconBg: 'bg-primary-light',
     iconColor: 'text-primary-dark',
     title: '커스텀 템플릿',
@@ -34,7 +36,7 @@ const FEATURES: Feature[] = [
       '유저 스토리, API 설계, 기능 명세 등 프로젝트 유형에 맞는 기획 문서 템플릿을 선택하고 자동 생성합니다.',
   },
   {
-    icon: '⑂',
+    Icon: MdCode,
     iconBg: 'bg-surface',
     iconColor: 'text-ink',
     title: 'GitHub 이슈 자동 생성',
@@ -42,7 +44,7 @@ const FEATURES: Feature[] = [
       '완성된 기획 문서에서 바로 Epic, Story, Task 단위의 GitHub 이슈를 자동으로 생성하고 저장소에 반영합니다.',
   },
   {
-    icon: '✦',
+    Icon: MdRateReview,
     iconBg: 'bg-ai-bg',
     iconColor: 'text-ai',
     title: 'AI 문서 피드백',
@@ -51,17 +53,13 @@ const FEATURES: Feature[] = [
   },
 ];
 
-function FeatureCard({ icon, iconBg, iconColor, title, description }: Feature) {
+function FeatureCard({ Icon, iconBg, iconColor, title, description }: Feature) {
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-border bg-white p-6 transition-shadow hover:shadow-md">
       <div
-        className={cn(
-          'flex h-10 w-10 items-center justify-center rounded-md text-lg',
-          iconBg,
-          iconColor
-        )}
+        className={cn('flex h-10 w-10 items-center justify-center rounded-md', iconBg, iconColor)}
       >
-        {icon}
+        <Icon size={22} />
       </div>
       <h3 className="text-lg font-semibold text-ink">{title}</h3>
       <p className="leading-relaxed text-ink-muted" style={{ fontSize: '0.8125rem' }}>

--- a/src/components/landing/FeaturesSection.tsx
+++ b/src/components/landing/FeaturesSection.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/shared/cn';
+
 interface Feature {
   icon: string;
   iconBg: string;
@@ -53,7 +55,11 @@ function FeatureCard({ icon, iconBg, iconColor, title, description }: Feature) {
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-border bg-white p-6 transition-shadow hover:shadow-md">
       <div
-        className={`flex h-10 w-10 items-center justify-center rounded-md text-lg ${iconBg} ${iconColor}`}
+        className={cn(
+          'flex h-10 w-10 items-center justify-center rounded-md text-lg',
+          iconBg,
+          iconColor
+        )}
       >
         {icon}
       </div>

--- a/src/components/landing/FeaturesSection.tsx
+++ b/src/components/landing/FeaturesSection.tsx
@@ -1,0 +1,101 @@
+interface Feature {
+  icon: string;
+  iconBg: string;
+  iconColor: string;
+  title: string;
+  description: string;
+}
+
+const FEATURES: Feature[] = [
+  {
+    icon: '✦',
+    iconBg: 'bg-ai-bg',
+    iconColor: 'text-ai',
+    title: 'AI 기획 문서 자동 생성',
+    description:
+      '핵심 아이디어만 입력하면 AI가 유저 시나리오, 기능 명세 초안을 자동으로 작성합니다. 논리적 허점까지 짚어드립니다.',
+  },
+  {
+    icon: '⌖',
+    iconBg: 'bg-primary-light',
+    iconColor: 'text-primary-dark',
+    title: '실시간 팀 협업',
+    description:
+      'Figma처럼 팀원들의 커서와 작업 현황을 실시간으로 확인하며 함께 문서를 완성합니다.',
+  },
+  {
+    icon: '▤',
+    iconBg: 'bg-primary-light',
+    iconColor: 'text-primary-dark',
+    title: '커스텀 템플릿',
+    description:
+      '유저 스토리, API 설계, 기능 명세 등 프로젝트 유형에 맞는 기획 문서 템플릿을 선택하고 자동 생성합니다.',
+  },
+  {
+    icon: '⑂',
+    iconBg: 'bg-surface',
+    iconColor: 'text-ink',
+    title: 'GitHub 이슈 자동 생성',
+    description:
+      '완성된 기획 문서에서 바로 Epic, Story, Task 단위의 GitHub 이슈를 자동으로 생성하고 저장소에 반영합니다.',
+  },
+  {
+    icon: '✦',
+    iconBg: 'bg-ai-bg',
+    iconColor: 'text-ai',
+    title: 'AI 문서 피드백',
+    description:
+      'AI가 논리적 일관성, 누락된 내용, 모호한 표현을 분석해 문서의 완성도를 높이는 구체적인 개선 방안을 제안합니다.',
+  },
+];
+
+function FeatureCard({ icon, iconBg, iconColor, title, description }: Feature) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-white p-6 transition-shadow hover:shadow-md">
+      <div
+        className={`flex h-10 w-10 items-center justify-center rounded-md text-lg ${iconBg} ${iconColor}`}
+      >
+        {icon}
+      </div>
+      <h3 className="text-lg font-semibold text-ink">{title}</h3>
+      <p className="leading-relaxed text-ink-muted" style={{ fontSize: '0.8125rem' }}>
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export default function FeaturesSection() {
+  return (
+    <section id="features" className="bg-sidebar px-6 py-24">
+      <div className="mx-auto max-w-6xl">
+        {/* Section header */}
+        <div className="mb-12 text-center">
+          <p className="mb-2 text-xl font-semibold uppercase tracking-widest text-primary">
+            주요 기능
+          </p>
+          <h2 className="mb-4 text-4xl font-bold text-ink">기획 프로세스의 모든 것을 하나로</h2>
+          <p className="mx-auto max-w-lg text-ink-muted" style={{ fontSize: '1rem' }}>
+            아이디어 구체화부터 GitHub 이슈 생성까지,
+            <br />
+            개발 팀의 기획 워크플로우를 하나의 공간에서 완성합니다.
+          </p>
+        </div>
+
+        {/* Feature grid */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.slice(0, 3).map((feature) => (
+            <FeatureCard key={feature.title} {...feature} />
+          ))}
+          <div className="contents lg:col-span-3 lg:flex lg:justify-center lg:gap-4">
+            {FEATURES.slice(3).map((feature) => (
+              <div key={feature.title} className="sm:col-span-1 lg:w-1/3">
+                <FeatureCard {...feature} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,0 +1,30 @@
+import Button from '@/components/ui/Button';
+import AppMockup from '@/components/landing/AppMockup';
+
+export default function HeroSection() {
+  return (
+    <section className="flex flex-col items-center px-6 pb-20 pt-32 text-center">
+      {/* Headline */}
+      <h1 className="mb-5 text-5xl font-bold leading-tight text-ink">
+        <span className="whitespace-nowrap">빈 페이지에서 완벽한 기획서까지,</span>
+        <br />
+        <span className="text-primary">AI와 팀이 함께</span>
+      </h1>
+
+      {/* Description */}
+      <p className="mb-8 max-w-xl leading-relaxed text-ink-muted" style={{ fontSize: '1rem' }}>
+        AI가 기획 문서 초안을 자동으로 작성하고, 팀원들과 실시간으로 협업하며,
+        <br />
+        완성된 기획을 바로 GitHub 이슈로 연결합니다.
+      </p>
+
+      {/* CTAs */}
+      <div className="mb-16 flex items-center gap-3">
+        <Button size="lg">무료로 시작하기</Button>
+      </div>
+
+      {/* Product mockup */}
+      <AppMockup />
+    </section>
+  );
+}

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router';
+
+export default function LandingFooter() {
+  return (
+    <footer className="border-t border-border bg-white px-6 py-10">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-6 sm:flex-row sm:justify-between">
+        {/* Logo */}
+        <Link to="/" className="flex items-center gap-1.5 no-underline">
+          <div className="flex h-6 w-6 items-center justify-center rounded bg-primary">
+            <span className="text-xs font-bold text-white">A</span>
+          </div>
+          <span className="text-sm font-bold text-ink">aidea</span>
+        </Link>
+
+        {/* Copyright */}
+        <p className="text-sm text-ink-muted">© 2025 Aidea. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router';
+import Button from '@/components/ui/Button';
+
+const NAV_LINKS = [
+  { label: '기능', href: '#features' },
+  { label: '워크플로우', href: '#workflow' },
+];
+
+export default function LandingHeader() {
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 border-b border-border bg-white/80 backdrop-blur-md">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
+        {/* Logo */}
+        <Link to="/" className="flex items-center gap-1.5 no-underline">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary">
+            <span className="text-sm font-bold text-white">A</span>
+          </div>
+          <span className="text-base font-bold text-ink">aidea</span>
+        </Link>
+
+        {/* Nav */}
+        <nav className="flex items-center gap-6">
+          {NAV_LINKS.map(({ label, href }) => (
+            <a
+              key={href}
+              href={href}
+              className="text-base text-ink-muted no-underline transition-colors hover:text-ink"
+            >
+              {label}
+            </a>
+          ))}
+        </nav>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm">
+            로그인
+          </Button>
+          <Button size="sm">무료로 시작하기</Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/landing/WorkflowSection.tsx
+++ b/src/components/landing/WorkflowSection.tsx
@@ -1,0 +1,88 @@
+interface Step {
+  number: string;
+  title: string;
+  description: string;
+  badge?: string;
+}
+
+const STEPS: Step[] = [
+  {
+    number: '01',
+    title: '아이디어 입력',
+    description:
+      '만들고 싶은 서비스의 핵심 아이디어를 자유롭게 입력합니다. 단 한 줄이어도 괜찮습니다.',
+  },
+  {
+    number: '02',
+    title: 'AI가 기획 문서 생성',
+    description:
+      'AI가 유저 시나리오, 기능 명세, API 설계 등 필요한 문서 초안을 자동으로 작성하고 논리적 허점을 짚어줍니다.',
+  },
+  {
+    number: '03',
+    title: '팀과 실시간 협업',
+    description:
+      '팀원을 초대하여 실시간으로 문서를 함께 완성합니다. 커서 위치와 수정 이력이 모두 기록됩니다.',
+  },
+  {
+    number: '04',
+    title: 'GitHub 이슈로 연동',
+    description:
+      '완성된 기획을 바탕으로 Epic, Story, Task 단위의 GitHub 이슈를 자동 생성하여 개발을 바로 시작합니다.',
+  },
+];
+
+function StepCard({ number, title, description, badge }: Step) {
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Step number */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-bold text-primary">{number}</span>
+        {badge && (
+          <span className="rounded-md bg-ai-bg px-2 py-0.5 text-xs font-semibold text-ai">
+            {badge}
+          </span>
+        )}
+      </div>
+
+      {/* Connector line */}
+      <div className="h-px w-full bg-border" />
+
+      {/* Content */}
+      <div className="pt-1">
+        <h3 className="mb-2 font-semibold text-ink" style={{ fontSize: '1rem' }}>
+          {title}
+        </h3>
+        <p className="leading-relaxed text-ink-muted" style={{ fontSize: '0.8125rem' }}>
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function WorkflowSection() {
+  return (
+    <section id="workflow" className="px-6 py-24">
+      <div className="mx-auto max-w-6xl">
+        {/* Section header */}
+        <div className="mb-16 text-center">
+          <p className="mb-2 text-xl font-semibold uppercase tracking-widest text-primary">
+            워크플로우
+          </p>
+          <h2 className="mb-4 text-4xl font-bold text-ink">어떻게 시작하나요?</h2>
+          <p className="mx-auto max-w-md text-ink-muted" style={{ fontSize: '1rem' }}>
+            4단계만으로 아이디어를 실제 개발 이슈로 연결합니다.
+          </p>
+        </div>
+
+        {/* Steps */}
+        <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-4">
+          {STEPS.map((step) => (
+            <StepCard key={step.number} {...step} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/WorkflowSection.tsx
+++ b/src/components/landing/WorkflowSection.tsx
@@ -1,8 +1,10 @@
+import { MdAutoAwesome } from 'react-icons/md';
+
 interface Step {
   number: string;
   title: string;
   description: string;
-  badge?: string;
+  aiBadge?: boolean;
 }
 
 const STEPS: Step[] = [
@@ -32,15 +34,16 @@ const STEPS: Step[] = [
   },
 ];
 
-function StepCard({ number, title, description, badge }: Step) {
+function StepCard({ number, title, description, aiBadge }: Step) {
   return (
     <div className="flex flex-col gap-3">
       {/* Step number */}
       <div className="flex items-center gap-2">
         <span className="text-sm font-bold text-primary">{number}</span>
-        {badge && (
-          <span className="rounded-md bg-ai-bg px-2 py-0.5 text-xs font-semibold text-ai">
-            {badge}
+        {aiBadge && (
+          <span className="inline-flex items-center gap-1 rounded-md bg-ai-bg px-2 py-0.5 text-xs font-semibold text-ai">
+            <MdAutoAwesome />
+            AI
           </span>
         )}
       </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes } from 'react';
+import { cn } from '@/shared/cn';
 
 type Variant = 'primary' | 'secondary' | 'ghost';
 type Size = 'sm' | 'md' | 'lg';
@@ -29,7 +30,12 @@ export default function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`inline-flex cursor-pointer items-center justify-center gap-2 rounded-md font-semibold transition-colors ${variantClass[variant]} ${sizeClass[size]} ${className}`}
+      className={cn(
+        'inline-flex cursor-pointer items-center justify-center gap-2 rounded-md font-semibold transition-colors',
+        variantClass[variant],
+        sizeClass[size],
+        className
+      )}
       {...props}
     >
       {children}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,38 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'ghost';
+type Size = 'sm' | 'md' | 'lg';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+}
+
+const variantClass: Record<Variant, string> = {
+  primary: 'bg-primary text-white hover:bg-primary-dark',
+  secondary: 'bg-white text-ink border border-border hover:bg-surface',
+  ghost: 'text-ink-muted hover:text-ink hover:bg-surface',
+};
+
+const sizeClass: Record<Size, string> = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-10 px-4 text-base',
+  lg: 'h-12 px-6 text-lg',
+};
+
+export default function Button({
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={`inline-flex cursor-pointer items-center justify-center gap-2 rounded-md font-semibold transition-colors ${variantClass[variant]} ${sizeClass[size]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
-import App from './App.tsx';
+import App from '@/App';
 import { BrowserRouter } from 'react-router';
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,3 +1,21 @@
+import LandingHeader from '@/components/landing/LandingHeader';
+import HeroSection from '@/components/landing/HeroSection';
+import FeaturesSection from '@/components/landing/FeaturesSection';
+import WorkflowSection from '@/components/landing/WorkflowSection';
+import CTASection from '@/components/landing/CTASection';
+import LandingFooter from '@/components/landing/LandingFooter';
+
 export default function LandingPage() {
-  return <div>LandingPage</div>;
+  return (
+    <div className="min-h-screen bg-white font-sans">
+      <LandingHeader />
+      <main>
+        <HeroSection />
+        <FeaturesSection />
+        <WorkflowSection />
+        <CTASection />
+      </main>
+      <LandingFooter />
+    </div>
+  );
 }

--- a/src/shared/cn.ts
+++ b/src/shared/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,7 +19,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,14 @@ import { defineConfig } from 'vite';
 import react, { reactCompilerPreset } from '@vitejs/plugin-react';
 import babel from '@rolldown/plugin-babel';
 import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), babel({ presets: [reactCompilerPreset()] })],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- Closes #37 


<br>

## 📝 작업 내용
- 랜딩 페이지 구현
- @ 경로 alias 설정
- Button 공통 유틸 컴포넌트 추가
- crlf, lf 모두 허용하도록 린트 규칙 추가
- cn 유틸 구현 및 적용
- react-icons 라이브러리 도입 및 적용    


<br>

## 🖼️ 스크린샷 (선택)

<img height="3240" alt="FireShot Capture 001 - aidea-front -  localhost" src="https://github.com/user-attachments/assets/49da8693-923e-469c-a76a-e90eb23af3cf" />


<br>

## 테스트 및 검증 내용
- 아직 UI 단계라서 테스트는 추가하지 않음

<br>

## 💬 리뷰 요구사항 (선택)
- 랜딩 페이지 디자인이나 문구 같은 것들 피드백 주시면 좋을 것 같아요


<br>

## 🧩 참고 사항 (선택)
- https://react-icons.github.io/react-icons/icons/md/
  - 아이콘 목록과 사용법을 확인할 수 있는 사이트입니다.
- alias 설정을 하면 "../../../" 이런 경로 대신에 루트 경로(`src/`)를 기준으로 import 경로를 세팅할 수 있습니다(`@/components`)
- cn 유틸을 사용하면 tailwind의 클래스들을 조건부 클래스들을 가독성 좋게 관리할 수 있습니다.