### PR TITLE
깃헙 로그인 연동

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,9 @@
+# 실제 백엔드 auth 테스트 시 true로 설정
+# true: auth 관련 API가 실제 백엔드로 전달됨 (GitHub OAuth 테스트용)
+# false(기본값): MSW가 auth API를 목킹함
+VITE_USE_REAL_AUTH=true
+
+# 백엔드 서버 주소
+# true 모드에서는 http://localhost:8080 설정 필요
+# false(MSW 목킹) 모드에서는 빈 값으로 유지
+VITE_API_BASE_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
-*.local
+
 
 # Editor directories and files
 .vscode/*

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,22 +1,20 @@
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import { currentUser, session } from '../db';
 import { requireAuth } from '../helpers';
 
-export const authHandlers = [
-  // GET /api/oauth2/callback/github — OAuth 완료, 세션 시작
-  http.get('/api/oauth2/callback/github', () => {
-    session.isLoggedIn = true;
+const USE_REAL_AUTH = import.meta.env.VITE_USE_REAL_AUTH === 'true';
 
-    return HttpResponse.json({
-      success: true,
-      code: null,
-      message: '로그인 성공',
-      data: null,
-    });
+export const authHandlers = [
+  // POST /api/dev/mock-login — MSW 목 모드 전용: 세션 시작 (실제 OAuth 대체)
+  http.post('/api/dev/mock-login', () => {
+    session.isLoggedIn = true;
+    return HttpResponse.json({ success: true, code: null, message: '목 로그인 성공', data: null });
   }),
 
   // POST /api/auth/refresh — 세션 기반이므로 로그인 상태면 항상 성공
   http.post('/api/auth/refresh', () => {
+    if (USE_REAL_AUTH) return passthrough();
+
     if (!session.isLoggedIn) {
       return HttpResponse.json(
         { success: false, code: 'AUTH_003', message: '유효하지 않은 토큰입니다.' },
@@ -34,6 +32,8 @@ export const authHandlers = [
 
   // POST /api/auth/logout — 세션 종료
   http.post('/api/auth/logout', () => {
+    if (USE_REAL_AUTH) return passthrough();
+
     const authError = requireAuth();
     if (authError) return authError;
 
@@ -49,6 +49,8 @@ export const authHandlers = [
 
   // GET /api/auth/me — 내 정보 조회 (인증 상태 확인)
   http.get('/api/auth/me', () => {
+    if (USE_REAL_AUTH) return passthrough();
+
     const authError = requireAuth();
     if (authError) return authError;
 

--- a/src/shared/apiClient.ts
+++ b/src/shared/apiClient.ts
@@ -1,10 +1,21 @@
 import axios from 'axios';
 import { useAuthStore } from '@/store/authStore';
 
+// 목 모드(VITE_USE_REAL_AUTH !== 'true')에서는 빈 baseURL → MSW가 동일 오리진 요청을 인터셉트
+// 실제 모드에서는 VITE_API_BASE_URL 사용
+const baseURL =
+  import.meta.env.VITE_USE_REAL_AUTH === 'true' ? (import.meta.env.VITE_API_BASE_URL ?? '') : '';
+
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
+  baseURL,
   headers: { 'Content-Type': 'application/json' },
-  withCredentials: true, // 쿠키 자동 전송
+  withCredentials: true,
+});
+
+// 인터셉터 없는 인스턴스 — refresh 전용으로만 사용
+const basicClient = axios.create({
+  baseURL,
+  withCredentials: true,
 });
 
 // ── Response interceptor: 401 시 refresh 후 재요청 ────────────
@@ -25,7 +36,6 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    // refresh 시도 없이 그냥 에러를 반환할 엔드포인트
     // /api/auth/me : 인증 상태 확인용으로 401은 정상 응답
     // /api/auth/refresh : refresh 자체가 실패한 경우
     const skipRefreshUrls = ['/api/auth/me', '/api/auth/refresh'];
@@ -33,7 +43,6 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    // 이미 갱신 중이면 대기열에 추가
     if (isRefreshing) {
       return new Promise((resolve, reject) => {
         failedQueue.push({
@@ -47,13 +56,14 @@ apiClient.interceptors.response.use(
     isRefreshing = true;
 
     try {
-      // body 없음 — refresh_token 쿠키가 자동으로 전송됨
-      await apiClient.post('/api/auth/refresh');
+      // basicClient 사용 — 인터셉터 재진입 없이 refresh 호출
+      await basicClient.post('/api/auth/refresh');
       flushQueue();
       return apiClient(originalRequest);
     } catch (refreshError) {
       flushQueue(refreshError);
       useAuthStore.getState().setAuthenticated(false);
+      window.location.href = '/';
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;

--- a/src/shared/useAuth.ts
+++ b/src/shared/useAuth.ts
@@ -1,20 +1,15 @@
-import { useNavigate } from 'react-router';
 import { apiClient } from './apiClient';
 import { useAuthStore } from '@/store/authStore';
 
 export function useAuth() {
   const { isAuthenticated, isLoading, setAuthenticated } = useAuthStore();
-  const navigate = useNavigate();
 
-  const login = async () => {
-    try {
-      await apiClient.get('/api/oauth2/callback/github');
-      setAuthenticated(true);
-      navigate('/');
-    } catch (error) {
-      setAuthenticated(false);
-      // TODO: toast 시스템 도입 시 에러 메시지 표시로 교체
-      console.error('로그인에 실패했습니다.', error);
+  const login = () => {
+    if (import.meta.env.VITE_USE_REAL_AUTH === 'true') {
+      window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/github`;
+    } else {
+      // MSW 목 모드: mock-login 엔드포인트로 세션 설정
+      apiClient.post('/api/dev/mock-login').then(() => setAuthenticated(true));
     }
   };
 
@@ -22,8 +17,7 @@ export function useAuth() {
     try {
       await apiClient.post('/api/auth/logout');
     } finally {
-      setAuthenticated(false);
-      navigate('/');
+      window.location.href = '/';
     }
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
> - Closes #46 


<br>

## 📝 작업 내용
- VITE_USE_REAL_AUTH=true 시 GitHub OAuth 리다이렉트 및 실제 API 사용
- 목 모드 전용 /api/dev/mock-login 핸들러 추가, OAuth 콜백 핸들러 제거
- USE_REAL_AUTH 플래그에 따라 refresh/logout/me 핸들러 passthrough 처리
- refresh 인터셉터에 순환 참조 방지용 basicClient 분리
- refresh 실패 시 window.location.href로 루트 리다이렉트


<br>

## 🖼️ 스크린샷 (선택)
<img width="1212" height="856" alt="스크린샷 2026-05-03 160140" src="https://github.com/user-attachments/assets/6ae28e64-2ff5-4720-a701-fab89a488c55" />

<img width="1918" height="862" alt="image" src="https://github.com/user-attachments/assets/7fed72ed-75a7-4544-8256-deb09ab08e33" />



<br>

## 🛠️ 테스트 및 검증 내용
- 백엔드와 직접 연동하여 테스트

<br>

### ⚠️실제 테스트 하는 방법
- 백엔드 실행
  - 백엔드 레포 클론
  - 환경변수 세팅
  - 백엔드 프로젝트 루트 폴더 터미널에서 `docker compose -f docker-compose.dev.yml up -d` 실행
  - 환경변수 세팅 및 실행 방법은 https://github.com/bu-capstone-4/Aidea-back/pull/56 참고
- 백엔드 실행 후 프론트엔드에서 pnpm dev로 서버 실행하면 됨
  - 만약 MSW로 작업을 하고 싶다면 `.env.local` 파일에서 `VITE_USE_REAL_AUTH`값을 false로 설정하면 됨
