### PR TITLE
Yjs 기반 AI 피드백 통신 구현

### DIFF
--- a/src/components/main/FeedbackModal.tsx
+++ b/src/components/main/FeedbackModal.tsx
@@ -6,14 +6,12 @@ interface FeedbackModalProps {
   isFeedbackModalOpen: boolean;
   toggleFeedbackModal: () => void;
   docId: string;
-  originalText: string;
 }
 
 export default function FeedbackModal({
   isFeedbackModalOpen,
   toggleFeedbackModal,
   docId,
-  originalText,
 }: FeedbackModalProps) {
   const { requestFeedback } = useFeedback();
   const [prompt, setPrompt] = useState('');
@@ -41,7 +39,7 @@ export default function FeedbackModal({
         <Button
           variant="primary"
           onClick={() => {
-            requestFeedback(docId, prompt, toggleFeedbackModal, originalText);
+            requestFeedback(docId, prompt, toggleFeedbackModal);
           }}
         >
           피드백 요청

--- a/src/components/main/Loading.tsx
+++ b/src/components/main/Loading.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  isLoading: boolean;
+}
+
+export default function Loading({ isLoading }: Props) {
+  if (!isLoading) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-[999]">
+      <div className="bg-white p-10 rounded-2xl shadow-xl flex flex-col items-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-600 border-t-transparent"></div>
+        <p className="mt-6 text-gray-700 font-medium">AI가 문서를 분석하고 있습니다...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -60,7 +60,6 @@ export default function MainContent() {
         isFeedbackModalOpen={isFeedbackModalOpen}
         toggleFeedbackModal={toggleFeedbackModal}
         docId={docId ?? ''}
-        originalText={doc.yjsBinary}
       />
 
       {(status === 'PENDING' || status === 'ANSWERING') && (

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -7,6 +7,7 @@ import FeedbackModal from './FeedbackModal';
 import { useState } from 'react';
 import SplitView from './SplitView';
 import { useFeedbackStore } from '@/store/FeedbackStore';
+import QuestionPanel from './QuestionPanel';
 
 const CURSOR_COLORS = ['#1971c2', '#e03131', '#2f9e44', '#f08c00', '#7048e8'];
 
@@ -16,6 +17,7 @@ export default function MainContent() {
   const { user } = useCurrentUser();
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
   const isSplitView = useFeedbackStore((state) => state.isSplitView);
+  const status = useFeedbackStore((state) => state.status);
 
   const toggleFeedbackModal = () => {
     setIsFeedbackModalOpen((prev) => !prev);
@@ -60,6 +62,23 @@ export default function MainContent() {
         docId={docId ?? ''}
         originalText={doc.yjsBinary}
       />
+
+      {(status === 'PENDING' || status === 'ANSWERING') && (
+        <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-[999]">
+          <div className="bg-white p-10 rounded-2xl shadow-xl flex flex-col items-center">
+            <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-600 border-t-transparent"></div>
+            <p className="mt-6 text-gray-700 font-medium">AI가 문서를 분석하고 있습니다...</p>
+          </div>
+        </div>
+      )}
+
+      {status === 'QUESTIONING' && (
+        <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-[999]">
+          <div className="bg-white rounded-2xl shadow-xl overflow-hidden w-full max-w-2xl max-h-[85vh] overflow-y-auto">
+            <QuestionPanel variant="fullscreen" />
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import SplitView from './SplitView';
 import { useFeedbackStore } from '@/store/FeedbackStore';
 import QuestionPanel from './QuestionPanel';
+import Loading from './Loading';
 
 const CURSOR_COLORS = ['#1971c2', '#e03131', '#2f9e44', '#f08c00', '#7048e8'];
 
@@ -33,19 +34,23 @@ export default function MainContent() {
   };
 
   return (
-    <main className="flex-1 overflow-y-auto bg-white">
-      {isSplitView ? (
-        <SplitView title={doc.title} />
-      ) : (
-        <div className="max-w-180 mx-auto px-24 md:px-10 sm:px-5 pt-5">
-          <div className="flex items-center gap-3 pb-4">
-            <h1 className="text-4xl font-bold text-[#1a1a1a] tracking-tight leading-tight">
-              {doc.title}
-            </h1>
-            <Button variant="feedback" size="sm" className="shrink-0" onClick={toggleFeedbackModal}>
-              + AI 피드백
-            </Button>
-          </div>
+    <main className="flex-1 overflow-y-auto bg-white relative">
+      {isSplitView && <SplitView title={doc.title} />}
+      <div
+        className={`${isSplitView ? 'hidden' : 'block'} max-w-180 mx-auto px-24 md:px-10 sm:px-5 pt-5`}
+      >
+        <div className="flex items-center gap-3 pb-4">
+          <h1 className="text-4xl font-bold text-[#1a1a1a] tracking-tight leading-tight">
+            {doc.title}
+          </h1>
+          <Button variant="feedback" size="sm" className="shrink-0" onClick={toggleFeedbackModal}>
+            + AI 피드백
+          </Button>
+        </div>
+
+        <QuestionPanel />
+
+        <div className={status === 'QUESTIONING' ? 'hidden' : 'block'}>
           <CollaborativeEditor
             key={docId}
             docId={docId}
@@ -54,7 +59,7 @@ export default function MainContent() {
             token=""
           />
         </div>
-      )}
+      </div>
 
       <FeedbackModal
         isFeedbackModalOpen={isFeedbackModalOpen}
@@ -62,22 +67,7 @@ export default function MainContent() {
         docId={docId ?? ''}
       />
 
-      {(status === 'PENDING' || status === 'ANSWERING') && (
-        <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-[999]">
-          <div className="bg-white p-10 rounded-2xl shadow-xl flex flex-col items-center">
-            <div className="h-12 w-12 animate-spin rounded-full border-4 border-blue-600 border-t-transparent"></div>
-            <p className="mt-6 text-gray-700 font-medium">AI가 문서를 분석하고 있습니다...</p>
-          </div>
-        </div>
-      )}
-
-      {status === 'QUESTIONING' && (
-        <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-[999]">
-          <div className="bg-white rounded-2xl shadow-xl overflow-hidden w-full max-w-2xl max-h-[85vh] overflow-y-auto">
-            <QuestionPanel variant="fullscreen" />
-          </div>
-        </div>
-      )}
+      <Loading isLoading={status === 'PENDING' || status === 'ANSWERING'} />
     </main>
   );
 }

--- a/src/components/main/MainSideBar.tsx
+++ b/src/components/main/MainSideBar.tsx
@@ -18,6 +18,7 @@ import { useTeamspaceStore } from '@/store/teamspaceStore';
 import { useTeamspaceDetail } from '@/hooks/useTeamspaceDetail';
 import type { DocumentType } from '@/mocks/types';
 import type { ElementType } from 'react';
+import { apiClient } from '@/shared/apiClient';
 
 const DOC_ICON: Record<DocumentType, ElementType> = {
   IDEA: MdLightbulb,
@@ -38,6 +39,22 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
   const { user } = useCurrentUser();
   const { currentTeamspaceId } = useTeamspaceStore();
   const { teamspace } = useTeamspaceDetail(currentTeamspaceId);
+
+  const handleAddDocument = async () => {
+    if (!currentTeamspaceId) return;
+    try {
+      // 8080 빼고 원래대로 복구
+      const res = await apiClient.post('/api/documents', {
+        teamspaceId: currentTeamspaceId,
+        type: 'IDEA',
+        title: '새 문서',
+      });
+      const newId = res.data?.data?.id || res.data?.id;
+      navigate(`/main/${newId}`);
+    } catch (error) {
+      console.error('문서 생성 실패:', error);
+    }
+  };
 
   return (
     <aside
@@ -96,6 +113,7 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
           size={isSideBarOpen ? 'sm' : 'icon'}
           icon={<MdAdd size={18} className="shrink-0" />}
           className={cn('text-gray-500', isSideBarOpen && 'w-full justify-start')}
+          onClick={handleAddDocument}
         >
           추가하기
         </Button>

--- a/src/components/main/MainSideBar.tsx
+++ b/src/components/main/MainSideBar.tsx
@@ -18,7 +18,6 @@ import { useTeamspaceStore } from '@/store/teamspaceStore';
 import { useTeamspaceDetail } from '@/hooks/useTeamspaceDetail';
 import type { DocumentType } from '@/mocks/types';
 import type { ElementType } from 'react';
-import { apiClient } from '@/shared/apiClient';
 
 const DOC_ICON: Record<DocumentType, ElementType> = {
   IDEA: MdLightbulb,
@@ -39,22 +38,6 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
   const { user } = useCurrentUser();
   const { currentTeamspaceId } = useTeamspaceStore();
   const { teamspace } = useTeamspaceDetail(currentTeamspaceId);
-
-  const handleAddDocument = async () => {
-    if (!currentTeamspaceId) return;
-    try {
-      // 8080 빼고 원래대로 복구
-      const res = await apiClient.post('/api/documents', {
-        teamspaceId: currentTeamspaceId,
-        type: 'IDEA',
-        title: '새 문서',
-      });
-      const newId = res.data?.data?.id || res.data?.id;
-      navigate(`/main/${newId}`);
-    } catch (error) {
-      console.error('문서 생성 실패:', error);
-    }
-  };
 
   return (
     <aside
@@ -113,7 +96,6 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
           size={isSideBarOpen ? 'sm' : 'icon'}
           icon={<MdAdd size={18} className="shrink-0" />}
           className={cn('text-gray-500', isSideBarOpen && 'w-full justify-start')}
-          onClick={handleAddDocument}
         >
           추가하기
         </Button>

--- a/src/components/main/QuestionPanel.tsx
+++ b/src/components/main/QuestionPanel.tsx
@@ -1,128 +1,169 @@
 import { useState } from 'react';
-import type { Question, Answer } from '@/types/document';
+import Button from '../ui/Button';
 import { useFeedbackStore } from '@/store/FeedbackStore';
-import { apiClient } from '@/shared/apiClient';
 
-interface Props {
-  variant: 'fullscreen' | 'side-panel';
+interface Question {
+  id: string;
+  text: string;
+  options?: string[];
 }
 
-export default function QuestionPanel({ variant }: Props) {
-  const { questions, feedbackId, setAnswering } = useFeedbackStore();
-  const [answers, setAnswers] = useState<Record<string, string>>({});
+const DUMMY_QUESTIONS: Question[] = [
+  {
+    id: 'q1',
+    text: '이 서비스의 주요 타깃 사용자는 누구인가요?',
+    options: [
+      '소규모 개발팀 (2~6인) / 사이드 프로젝트',
+      '대학교 팀 프로젝트 참여자',
+      '스타트업 초기 팀',
+      '비개발자 포함 혼합 팀',
+    ],
+  },
+  {
+    id: 'q2',
+    text: 'AI 피드백에서 가장 중점적으로 봐줬으면 하는 부분은?',
+    options: [
+      '기획 구조의 논리적 완성도',
+      '사용자 경험(UX) 관점의 개선점',
+      '기술 실현 가능성 검토',
+    ],
+  },
+  {
+    id: 'q3',
+    text: '저녁 뭐 먹어?',
+    options: ['치킨', '명태조림', '족발'],
+  },
+];
+
+export default function QuestionPanel() {
+  const status = useFeedbackStore((state) => state.status);
+  const [answers, setAnswers] = useState<Record<string, string>>({
+    q1: '소규모 개발팀 (2~6인) / 사이드 프로젝트',
+  });
 
   const handleSelect = (questionId: string, value: string) => {
     setAnswers((prev) => ({ ...prev, [questionId]: value }));
   };
-
-  const handleSubmit = async () => {
-    if (!feedbackId) return;
-
-    const result: Answer[] = Object.entries(answers).map(([questionId, value]) => ({
-      questionId,
-      value,
-    }));
-
-    try {
-      await apiClient.post(`/api/feedbacks/${feedbackId}/answer`, { answers: result });
-
-      if (setAnswering) {
-        setAnswering();
-      }
-      console.log('답변 제출 완료! 다시 피드백 대기 상태로 들어갑니다.');
-    } catch (error) {
-      console.error('답변 제출 실패:', error);
-    }
-  };
-
-  if (!questions) return null;
-
-  const containerClass =
-    variant === 'fullscreen'
-      ? 'fixed inset-0 bg-gray-50 z-40 overflow-auto p-8 flex flex-col items-center'
-      : 'w-[420px] h-full overflow-auto p-6 bg-white border-l';
+  if (status !== 'QUESTIONING') return null;
 
   return (
-    <div className={containerClass}>
-      <div className={variant === 'fullscreen' ? 'w-full max-w-2xl' : 'w-full'}>
-        <div className="flex items-center gap-2 mb-2">
-          <span className="text-purple-600 font-medium">+ Aldea</span>
+    <div className="w-full flex flex-col gap-6 bg-white">
+      <div className="bg-[#F4F0FF] rounded-xl p-6 border border-purple-50">
+        <div className="flex items-center gap-2 text-[#7C3AED] font-bold text-base mb-2">
+          <span className="text-xl">✦</span> Aidea
         </div>
-        <p className="text-sm text-gray-600 mb-1">
-          기획 내용을 검토했어요. 피드백을 드리기 전에 방향을 조금 더 명확하게 파악하고 싶어서요.
-        </p>
-        <p className="text-sm text-purple-600 mb-6">
-          몇 가지만 여쭤봐도 될까요? 선택하거나 직접 입력하실 수 있어요.
-        </p>
+        <div className="text-gray-800 text-sm leading-relaxed">
+          <p>
+            기획 내용을 검토했어요. 피드백을 드리기 전에 방향을 조금 더 명확하게 파악하고 싶어서요.
+          </p>
+          <p className="font-medium text-[#7C3AED] mt-1">
+            몇 가지만 여쭤봐도 될까요? 선택하거나 직접 입력하실 수 있어요.
+          </p>
+        </div>
+      </div>
 
-        {/* 🚨 TS 에러 해결: 매개변수에 명시적 타입 지정 */}
-        {questions.map((q: Question, idx: number) => (
-          <div key={q.id} className="mb-4 p-4 border rounded-lg bg-white">
-            <p className="font-medium text-sm mb-3">
-              {idx + 1}. {q.text}
-            </p>
+      <div className="flex flex-col gap-6">
+        {DUMMY_QUESTIONS.map((q, idx) => {
+          const currentAnswer = answers[q.id];
+          const isCustomSelected =
+            currentAnswer !== undefined && !q.options?.includes(currentAnswer);
 
-            {/* 🚨 TS 에러 해결: option 타입 지정 */}
-            {q.options?.map((option: string) => (
-              <label key={option} className="flex items-center gap-2 mb-2 cursor-pointer text-sm">
-                <input
-                  type="radio"
-                  name={q.id}
-                  value={option}
-                  checked={answers[q.id] === option}
-                  onChange={() => handleSelect(q.id, option)}
-                  className="accent-blue-600"
-                />
-                {option}
-              </label>
-            ))}
+          return (
+            <div key={q.id} className="border border-gray-200 rounded-2xl p-6 md:p-8 shadow-sm">
+              <div className="flex items-start gap-4 mb-6">
+                <div className="w-8 h-8 flex items-center justify-center bg-purple-100 text-[#7C3AED] rounded-full font-bold text-sm shrink-0">
+                  {idx + 1}
+                </div>
+                <h3 className="font-bold text-gray-900 text-lg pt-1">{q.text}</h3>
+              </div>
 
-            {q.options && (
-              <>
-                <label className="flex items-center gap-2 cursor-pointer text-sm">
-                  <input
-                    type="radio"
-                    name={q.id}
-                    value="__custom__"
-                    checked={!!answers[q.id] && !q.options.includes(answers[q.id])}
-                    onChange={() => handleSelect(q.id, '')}
-                    className="accent-blue-600"
-                  />
-                  ✏️ 직접 입력
-                </label>
-                {!!answers[q.id] && !q.options.includes(answers[q.id]) && (
-                  <input
-                    className="mt-2 w-full border rounded px-3 py-2 text-sm
-                               focus:outline-none focus:ring-2 focus:ring-blue-300"
-                    placeholder="직접 입력해주세요..."
-                    value={answers[q.id]}
-                    onChange={(e) => handleSelect(q.id, e.target.value)}
-                  />
+              <div className="flex flex-col gap-3">
+                {q.options?.map((option) => {
+                  const isSelected = currentAnswer === option;
+
+                  return (
+                    <label
+                      key={option}
+                      className={`flex items-center gap-3 p-4 border-2 rounded-xl cursor-pointer transition-colors ${
+                        isSelected
+                          ? 'border-blue-500 bg-blue-50'
+                          : 'border-transparent bg-gray-50 hover:bg-gray-100'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={q.id}
+                        checked={isSelected}
+                        onChange={() => handleSelect(q.id, option)}
+                        className="w-5 h-5 accent-blue-600 cursor-pointer"
+                      />
+                      <span
+                        className={`text-sm ${
+                          isSelected ? 'text-blue-700 font-semibold' : 'text-gray-700 font-medium'
+                        }`}
+                      >
+                        {option}
+                      </span>
+                    </label>
+                  );
+                })}
+
+                {q.options && (
+                  <div className="flex flex-col gap-2 mt-1">
+                    <label
+                      className={`flex items-center gap-3 p-4 border-2 rounded-xl cursor-pointer transition-colors ${
+                        isCustomSelected
+                          ? 'border-blue-500 bg-blue-50'
+                          : 'border-transparent bg-gray-50 hover:bg-gray-100'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={q.id}
+                        checked={isCustomSelected}
+                        onChange={() => handleSelect(q.id, '')}
+                        className="w-5 h-5 accent-blue-600 cursor-pointer"
+                      />
+                      <span
+                        className={`text-sm ${
+                          isCustomSelected
+                            ? 'text-blue-700 font-semibold'
+                            : 'text-gray-700 font-medium'
+                        }`}
+                      >
+                        ✏️ 직접 입력
+                      </span>
+                    </label>
+
+                    {isCustomSelected && (
+                      <input
+                        type="text"
+                        placeholder="직접 입력해주세요..."
+                        value={currentAnswer || ''}
+                        onChange={(e) => handleSelect(q.id, e.target.value)}
+                        className="w-full border border-blue-300 rounded-xl px-4 py-4 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+                        autoFocus
+                      />
+                    )}
+                  </div>
                 )}
-              </>
-            )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
 
-            {!q.options && (
-              <input
-                className="w-full border rounded px-3 py-2 text-sm
-                           focus:outline-none focus:ring-2 focus:ring-blue-300"
-                placeholder="직접 입력해주세요..."
-                value={answers[q.id] ?? ''}
-                onChange={(e) => handleSelect(q.id, e.target.value)}
-              />
-            )}
-          </div>
-        ))}
-
-        <button
-          onClick={handleSubmit}
-          className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium
-                     hover:bg-blue-700 transition-colors"
+      <div className="mt-8 flex flex-col items-center gap-4 pb-10">
+        <Button
+          onClick={() => console.log('제출된 데이터:', answers)}
+          className="w-full max-w-lg py-4 bg-blue-600 text-white rounded-xl font-bold text-lg hover:bg-blue-700 transition-colors shadow-md"
         >
-          답변 완료 — AI 피드백 받기 →
-        </button>
-        <p className="text-center text-xs text-gray-400 mt-2">
-          모든 질문에 답하지 않아도 피드백을 받을 수 있어요. 답변할수록 더 정확한 피드백을 드립니다.
+          AI 피드백 받기
+        </Button>
+        <p className="text-gray-400 text-xs text-center font-medium">
+          모든 질문에 답하지 않아도 피드백을 받을 수 있어요.
+          <br />
+          답변할수록 더 정확한 피드백을 드릴 수 있습니다.
         </p>
       </div>
     </div>

--- a/src/components/main/QuestionPanel.tsx
+++ b/src/components/main/QuestionPanel.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import type { Question, Answer } from '@/types/document';
+import { useFeedbackStore } from '@/store/FeedbackStore';
+import { apiClient } from '@/shared/apiClient';
+
+interface Props {
+  variant: 'fullscreen' | 'side-panel';
+}
+
+export default function QuestionPanel({ variant }: Props) {
+  const { questions, feedbackId, setAnswering } = useFeedbackStore();
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+
+  const handleSelect = (questionId: string, value: string) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+  };
+
+  const handleSubmit = async () => {
+    if (!feedbackId) return;
+
+    const result: Answer[] = Object.entries(answers).map(([questionId, value]) => ({
+      questionId,
+      value,
+    }));
+
+    try {
+      await apiClient.post(`/api/feedbacks/${feedbackId}/answer`, { answers: result });
+
+      if (setAnswering) {
+        setAnswering();
+      }
+      console.log('답변 제출 완료! 다시 피드백 대기 상태로 들어갑니다.');
+    } catch (error) {
+      console.error('답변 제출 실패:', error);
+    }
+  };
+
+  if (!questions) return null;
+
+  const containerClass =
+    variant === 'fullscreen'
+      ? 'fixed inset-0 bg-gray-50 z-40 overflow-auto p-8 flex flex-col items-center'
+      : 'w-[420px] h-full overflow-auto p-6 bg-white border-l';
+
+  return (
+    <div className={containerClass}>
+      <div className={variant === 'fullscreen' ? 'w-full max-w-2xl' : 'w-full'}>
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-purple-600 font-medium">+ Aldea</span>
+        </div>
+        <p className="text-sm text-gray-600 mb-1">
+          기획 내용을 검토했어요. 피드백을 드리기 전에 방향을 조금 더 명확하게 파악하고 싶어서요.
+        </p>
+        <p className="text-sm text-purple-600 mb-6">
+          몇 가지만 여쭤봐도 될까요? 선택하거나 직접 입력하실 수 있어요.
+        </p>
+
+        {/* 🚨 TS 에러 해결: 매개변수에 명시적 타입 지정 */}
+        {questions.map((q: Question, idx: number) => (
+          <div key={q.id} className="mb-4 p-4 border rounded-lg bg-white">
+            <p className="font-medium text-sm mb-3">
+              {idx + 1}. {q.text}
+            </p>
+
+            {/* 🚨 TS 에러 해결: option 타입 지정 */}
+            {q.options?.map((option: string) => (
+              <label key={option} className="flex items-center gap-2 mb-2 cursor-pointer text-sm">
+                <input
+                  type="radio"
+                  name={q.id}
+                  value={option}
+                  checked={answers[q.id] === option}
+                  onChange={() => handleSelect(q.id, option)}
+                  className="accent-blue-600"
+                />
+                {option}
+              </label>
+            ))}
+
+            {q.options && (
+              <>
+                <label className="flex items-center gap-2 cursor-pointer text-sm">
+                  <input
+                    type="radio"
+                    name={q.id}
+                    value="__custom__"
+                    checked={!!answers[q.id] && !q.options.includes(answers[q.id])}
+                    onChange={() => handleSelect(q.id, '')}
+                    className="accent-blue-600"
+                  />
+                  ✏️ 직접 입력
+                </label>
+                {!!answers[q.id] && !q.options.includes(answers[q.id]) && (
+                  <input
+                    className="mt-2 w-full border rounded px-3 py-2 text-sm
+                               focus:outline-none focus:ring-2 focus:ring-blue-300"
+                    placeholder="직접 입력해주세요..."
+                    value={answers[q.id]}
+                    onChange={(e) => handleSelect(q.id, e.target.value)}
+                  />
+                )}
+              </>
+            )}
+
+            {!q.options && (
+              <input
+                className="w-full border rounded px-3 py-2 text-sm
+                           focus:outline-none focus:ring-2 focus:ring-blue-300"
+                placeholder="직접 입력해주세요..."
+                value={answers[q.id] ?? ''}
+                onChange={(e) => handleSelect(q.id, e.target.value)}
+              />
+            )}
+          </div>
+        ))}
+
+        <button
+          onClick={handleSubmit}
+          className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium
+                     hover:bg-blue-700 transition-colors"
+        >
+          답변 완료 — AI 피드백 받기 →
+        </button>
+        <p className="text-center text-xs text-gray-400 mt-2">
+          모든 질문에 답하지 않아도 피드백을 받을 수 있어요. 답변할수록 더 정확한 피드백을 드립니다.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main/SplitView.tsx
+++ b/src/components/main/SplitView.tsx
@@ -1,7 +1,6 @@
 import useFeedback from '@/hooks/useFeedback';
 import { useFeedbackStore } from '@/store/FeedbackStore';
 import VersionPanel from './VersionPanel';
-import { useMemo } from 'react';
 import * as Y from 'yjs';
 
 interface SplitViewProps {
@@ -12,13 +11,10 @@ export default function FeedbackSplitView({ title }: SplitViewProps) {
   const { revisedText, feedbackId, documentId, ydoc } = useFeedbackStore();
   const { chooseVersion } = useFeedback();
 
-  const aiDoc = useMemo(() => {
-    const d = new Y.Doc();
-    if (revisedText) {
-      Y.applyUpdate(d, revisedText, 'remote');
-    }
-    return d;
-  }, [revisedText]);
+  const aiDoc = new Y.Doc();
+  if (revisedText) {
+    Y.applyUpdate(aiDoc, revisedText, 'remote');
+  }
 
   return (
     <div className="flex flex-col h-full w-full max-w-6xl mx-auto p-6 gap-4 bg-white">

--- a/src/components/main/SplitView.tsx
+++ b/src/components/main/SplitView.tsx
@@ -7,7 +7,7 @@ interface SplitViewProps {
 }
 
 export default function FeedbackSplitView({ title }: SplitViewProps) {
-  const { originalText, revisedText, feedbackId } = useFeedbackStore();
+  const { originalText, revisedText, feedbackId, documentId, ydoc } = useFeedbackStore();
   const { chooseVersion } = useFeedback();
 
   return (
@@ -29,14 +29,22 @@ export default function FeedbackSplitView({ title }: SplitViewProps) {
           panelTitle="수정 전"
           content={originalText}
           aiMark={false}
-          onSelect={() => chooseVersion('ORIGINAL')}
+          onSelect={() => {
+            if (ydoc) {
+              chooseVersion('ORIGINAL', documentId, feedbackId, ydoc);
+            }
+          }}
         />
 
         <VersionPanel
           panelTitle="AI 피드백 후"
           content={revisedText}
           aiMark={true}
-          onSelect={() => chooseVersion('AI', feedbackId)}
+          onSelect={() => {
+            if (ydoc) {
+              chooseVersion('AI', documentId, feedbackId, ydoc);
+            }
+          }}
         />
       </div>
     </div>

--- a/src/components/main/SplitView.tsx
+++ b/src/components/main/SplitView.tsx
@@ -1,14 +1,24 @@
 import useFeedback from '@/hooks/useFeedback';
 import { useFeedbackStore } from '@/store/FeedbackStore';
 import VersionPanel from './VersionPanel';
+import { useMemo } from 'react';
+import * as Y from 'yjs';
 
 interface SplitViewProps {
   title: string;
 }
 
 export default function FeedbackSplitView({ title }: SplitViewProps) {
-  const { originalText, revisedText, feedbackId, documentId, ydoc } = useFeedbackStore();
+  const { revisedText, feedbackId, documentId, ydoc } = useFeedbackStore();
   const { chooseVersion } = useFeedback();
+
+  const aiDoc = useMemo(() => {
+    const d = new Y.Doc();
+    if (revisedText) {
+      Y.applyUpdate(d, revisedText, 'remote');
+    }
+    return d;
+  }, [revisedText]);
 
   return (
     <div className="flex flex-col h-full w-full max-w-6xl mx-auto p-6 gap-4 bg-white">
@@ -27,22 +37,22 @@ export default function FeedbackSplitView({ title }: SplitViewProps) {
       <div className="flex gap-6 h-full min-h-0">
         <VersionPanel
           panelTitle="수정 전"
-          content={originalText}
+          content={ydoc}
           aiMark={false}
           onSelect={() => {
             if (ydoc) {
-              chooseVersion('ORIGINAL', documentId, feedbackId, ydoc);
+              chooseVersion('ORIGINAL', feedbackId, documentId, ydoc);
             }
           }}
         />
 
         <VersionPanel
           panelTitle="AI 피드백 후"
-          content={revisedText}
+          content={aiDoc}
           aiMark={true}
           onSelect={() => {
             if (ydoc) {
-              chooseVersion('AI', documentId, feedbackId, ydoc);
+              chooseVersion('AI', feedbackId, documentId, ydoc);
             }
           }}
         />

--- a/src/components/main/VersionPanel.tsx
+++ b/src/components/main/VersionPanel.tsx
@@ -1,13 +1,27 @@
+import { useCreateBlockNote } from '@blocknote/react';
+import { BlockNoteView } from '@blocknote/mantine';
 import Button from '../ui/Button';
+import * as Y from 'yjs';
 
 interface VersionPanelProps {
   panelTitle: string;
-  content: string | Uint8Array;
+  content: Y.Doc | null;
   aiMark?: boolean;
   onSelect: () => void;
 }
 
 export default function VersionPanel({ panelTitle, content, aiMark, onSelect }: VersionPanelProps) {
+  const editor = useCreateBlockNote({
+    collaboration: {
+      fragment: (content ?? new Y.Doc()).getXmlFragment('document-store'),
+      user: {
+        name: '',
+        color: '',
+      },
+    },
+    editable: false,
+  });
+
   return (
     <div className="group flex flex-col flex-1 border border-gray-200 rounded-xl bg-white overflow-hidden hover:border-blue-500 hover:shadow-md transition-all duration-300">
       <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 group-hover:border-blue-100 transition-colors">
@@ -26,7 +40,7 @@ export default function VersionPanel({ panelTitle, content, aiMark, onSelect }: 
 
       <div className="flex-1 p-6 overflow-y-auto">
         <div className="whitespace-pre-wrap leading-relaxed group-hover:text-gray-800 transition-colors">
-          {content}
+          <BlockNoteView editor={editor} editable={false} />
         </div>
       </div>
 

--- a/src/components/main/VersionPanel.tsx
+++ b/src/components/main/VersionPanel.tsx
@@ -2,7 +2,7 @@ import Button from '../ui/Button';
 
 interface VersionPanelProps {
   panelTitle: string;
-  content: string;
+  content: string | Uint8Array;
   aiMark?: boolean;
   onSelect: () => void;
 }

--- a/src/hooks/useCollabEditor.ts
+++ b/src/hooks/useCollabEditor.ts
@@ -55,7 +55,16 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
         updates?: string[];
         update?: string;
         event: string;
-        data: { yjsBinary: string };
+        data?: {
+          feedbackId?: string;
+          requestedBy?: number;
+          code?: string;
+          message?: string;
+          yjsBinary?: string;
+          status?: string;
+          selectedVersion?: 'ORIGINAL' | 'AI';
+          appliedBy?: number;
+        };
       };
 
       if (msg.type === 'doc:init') {
@@ -71,10 +80,31 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
         Y.applyUpdate(doc, base64ToUint8Array(msg.update), 'remote');
       }
 
-      if (msg.event === 'feedback:version-applied') {
+      const feedbackStore = useFeedbackStore.getState();
+
+      if (msg.event === 'feedback:start' && msg.data?.feedbackId) {
+        const { feedbackId } = msg.data;
+        feedbackStore.setPending(docId, feedbackId);
+      }
+
+      if (msg.event === 'feedback:ready' && msg.data?.feedbackId && msg.data?.yjsBinary) {
+        const { feedbackId, yjsBinary } = msg.data;
+        feedbackStore.setDone(feedbackId, base64ToUint8Array(yjsBinary));
+      }
+
+      if (msg.event === 'feedback:version-applied' && msg.data?.yjsBinary) {
         const { yjsBinary } = msg.data;
-        Y.applyUpdate(doc, base64ToUint8Array(yjsBinary), 'remote');
-        useFeedbackStore.getState().acceptFeedback();
+        const newDoc = new Y.Doc();
+        Y.applyUpdate(newDoc, base64ToUint8Array(yjsBinary), 'remote');
+        Y.applyUpdate(doc, Y.encodeStateAsUpdate(newDoc), 'remote');
+        newDoc.destroy();
+        feedbackStore.acceptFeedback();
+      }
+
+      if (msg.event === 'feedback:error' && msg.data?.message) {
+        const { message } = msg.data;
+        console.log(message);
+        feedbackStore.resetFeedback();
       }
     };
 

--- a/src/hooks/useCollabEditor.ts
+++ b/src/hooks/useCollabEditor.ts
@@ -54,6 +54,8 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
         type: string;
         updates?: string[];
         update?: string;
+        event: string;
+        data: { yjsBinary: string };
       };
 
       if (msg.type === 'doc:init') {
@@ -67,6 +69,12 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
       if (msg.type === 'doc:update' && msg.update) {
         if (!initializedRef.current) return;
         Y.applyUpdate(doc, base64ToUint8Array(msg.update), 'remote');
+      }
+
+      if (msg.event === 'feedback:version-applied') {
+        const { yjsBinary } = msg.data;
+        Y.applyUpdate(doc, base64ToUint8Array(yjsBinary), 'remote');
+        useFeedbackStore.getState().acceptFeedback();
       }
     };
 

--- a/src/hooks/useCollabEditor.ts
+++ b/src/hooks/useCollabEditor.ts
@@ -3,6 +3,7 @@ import * as Y from 'yjs';
 import { WebsocketProvider } from 'y-websocket';
 import { useCreateBlockNote } from '@blocknote/react';
 import { ko } from '@blocknote/core/locales';
+import { useFeedbackStore } from '@/store/FeedbackStore';
 
 function base64ToUint8Array(b64: string): Uint8Array {
   return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
@@ -31,6 +32,13 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
 
   const [connected, setConnected] = useState(false);
   const initializedRef = useRef(false);
+  const { setYdoc } = useFeedbackStore();
+
+  useEffect(() => {
+    if (doc) {
+      setYdoc(doc);
+    }
+  }, [doc, setYdoc]);
 
   useEffect(() => {
     const ws = new WebSocket(`${import.meta.env.VITE_WS_BASE_URL}/ws/documents/${docId}`);

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -3,13 +3,12 @@ import { useFeedbackStore } from '@/store/FeedbackStore';
 import * as Y from 'yjs';
 
 export default function useFeedback() {
-  const { setPending, setDone, acceptFeedback } = useFeedbackStore();
+  const { setPending, acceptFeedback } = useFeedbackStore();
 
   const requestFeedback = async (
     documentId: string,
     prompt: string | null,
-    closeModal: () => void,
-    originalText: string
+    closeModal: () => void
   ) => {
     try {
       closeModal();
@@ -18,7 +17,6 @@ export default function useFeedback() {
       });
       const { feedbackId } = res.data.data;
       setPending(documentId, feedbackId);
-      setDone(originalText, '서버에서 받아온 revisedText');
     } catch (error) {
       console.error(error);
     }
@@ -32,7 +30,7 @@ export default function useFeedback() {
   ) => {
     try {
       const res = await apiClient.post(
-        `/api/documents/${documentId}/feedback/${feedbackId}/select`,
+        `/api/documents/${documentId}/feedback/${feedbackId}/accept`,
         {
           selectedVersion: target,
         }

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/shared/apiClient';
 import { useFeedbackStore } from '@/store/FeedbackStore';
+import * as Y from 'yjs';
 
 export default function useFeedback() {
   const { setPending, setDone, acceptFeedback } = useFeedbackStore();
@@ -17,38 +18,35 @@ export default function useFeedback() {
       });
       const { feedbackId } = res.data.data;
       setPending(documentId, feedbackId);
-      const eventSource = new EventSource(
-        `${import.meta.env.VITE_API_BASE_URL}/api/feedbacks / ${feedbackId} / events`,
-        { withCredentials: true }
-      );
-      eventSource.addEventListener('feedback:questioning', (e) => {
-        const data = JSON.parse(e.data);
-        console.log(data);
-      });
-      eventSource.addEventListener('feedback:ready', (e) => {
-        const data = JSON.parse(e.data);
-        const yjsBinary = Uint8Array.from(atob(data.yjsBinary), (c) => c.charCodeAt(0));
-        setDone(originalText, yjsBinary);
-        eventSource.close();
-      });
-      // setDone(originalText, '서버에서 받아온 revisedText');
+      setDone(originalText, '서버에서 받아온 revisedText');
     } catch (error) {
       console.error(error);
     }
   };
 
-  const chooseVersion = async (target: 'ORIGINAL' | 'AI', feedbackId?: string) => {
-    if (target === 'AI' && feedbackId) {
-      try {
-        const res = await apiClient.post(`/api/feedbacks/${feedbackId}/accept`);
+  const chooseVersion = async (
+    target: 'ORIGINAL' | 'AI',
+    feedbackId: string,
+    documentId: string,
+    ydoc: Y.Doc
+  ) => {
+    try {
+      const res = await apiClient.post(
+        `/api/documents/${documentId}/feedback/${feedbackId}/select`,
+        {
+          selectedVersion: target,
+        }
+      );
+      if (target === 'AI' && feedbackId) {
         const { yjsBinary } = res.data.data;
-        console.log(yjsBinary);
+        const binaryUpdate = Uint8Array.from(atob(yjsBinary), (c) => c.charCodeAt(0));
+        Y.applyUpdate(ydoc, binaryUpdate);
         acceptFeedback();
-      } catch (error) {
-        console.error(error);
+      } else {
+        acceptFeedback();
       }
-    } else {
-      acceptFeedback();
+    } catch (error) {
+      console.error(error);
     }
   };
 

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -17,7 +17,21 @@ export default function useFeedback() {
       });
       const { feedbackId } = res.data.data;
       setPending(documentId, feedbackId);
-      setDone(originalText, '서버에서 받아온 revisedText');
+      const eventSource = new EventSource(
+        `${import.meta.env.VITE_API_BASE_URL}/api/feedbacks / ${feedbackId} / events`,
+        { withCredentials: true }
+      );
+      eventSource.addEventListener('feedback:questioning', (e) => {
+        const data = JSON.parse(e.data);
+        console.log(data);
+      });
+      eventSource.addEventListener('feedback:ready', (e) => {
+        const data = JSON.parse(e.data);
+        const yjsBinary = Uint8Array.from(atob(data.yjsBinary), (c) => c.charCodeAt(0));
+        setDone(originalText, yjsBinary);
+        eventSource.close();
+      });
+      // setDone(originalText, '서버에서 받아온 revisedText');
     } catch (error) {
       console.error(error);
     }

--- a/src/mocks/types.ts
+++ b/src/mocks/types.ts
@@ -1,6 +1,6 @@
 export type DocumentType = 'IDEA' | 'PLAN' | 'USER_SCENARIO' | 'API_SPEC' | 'ERD';
 export type TeamspaceStatus = 'CREATING' | 'CREATED';
-export type FeedbackStatus = 'PENDING' | 'DONE' | 'ACCEPTED';
+export type FeedbackStatus = 'IDLE' | 'PENDING' | 'QUESTIONING' | 'ANSWERING' | 'DONE' | 'ACCEPTED';
 
 export interface UserResponse {
   id: number;

--- a/src/store/FeedbackStore.ts
+++ b/src/store/FeedbackStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { FeedbackStatus } from '@/mocks/types';
+import type { Question } from '@/types/document';
 
 interface FeedbackState {
   isSplitView: boolean;
@@ -7,19 +8,23 @@ interface FeedbackState {
   feedbackId: string;
   status: FeedbackStatus;
   originalText: string;
-  revisedText: string;
+  questions: Question[] | null;
+  revisedText: string | Uint8Array;
   setPending: (docId: string, feedId: string) => void;
-  setDone: (original: string, revised: string) => void;
+  setDone: (original: string, revised: string | Uint8Array) => void;
   acceptFeedback: () => void;
+  setAnswering: () => void;
+  setQuestioning: (questions: Question[]) => void;
 }
 
 export const useFeedbackStore = create<FeedbackState>()((set) => ({
   isSplitView: false,
   documentId: '',
   feedbackId: '',
-  status: 'PENDING', //초깃값 pending?
+  status: 'IDLE',
   originalText: '',
   revisedText: '',
+  questions: null,
 
   setPending: (docId, feedId) =>
     set({
@@ -40,5 +45,17 @@ export const useFeedbackStore = create<FeedbackState>()((set) => ({
     set({
       status: 'ACCEPTED',
       isSplitView: false,
+    }),
+
+  setQuestioning: (questions) =>
+    set({
+      questions: questions,
+      status: 'QUESTIONING',
+    }),
+
+  setAnswering: () =>
+    set({
+      questions: null,
+      status: 'ANSWERING',
     }),
 }));

--- a/src/store/FeedbackStore.ts
+++ b/src/store/FeedbackStore.ts
@@ -8,25 +8,24 @@ interface FeedbackState {
   documentId: string;
   feedbackId: string;
   status: FeedbackStatus;
-  originalText: string;
   questions: Question[] | null;
-  revisedText: string | Uint8Array;
+  revisedText: Uint8Array | null;
   ydoc: Y.Doc | null;
   setPending: (docId: string, feedId: string) => void;
-  setDone: (original: string, revised: string | Uint8Array) => void;
+  setDone: (feedId: string, revised: Uint8Array) => void;
   acceptFeedback: () => void;
   setAnswering: () => void;
   setQuestioning: (questions: Question[]) => void;
   setYdoc: (doc: Y.Doc) => void;
+  resetFeedback: () => void;
 }
 
 export const useFeedbackStore = create<FeedbackState>()((set) => ({
   isSplitView: false,
   documentId: '',
   feedbackId: '',
-  status: 'DONE',
-  originalText: '',
-  revisedText: '',
+  status: 'IDLE',
+  revisedText: null,
   questions: null,
   ydoc: null,
 
@@ -38,9 +37,9 @@ export const useFeedbackStore = create<FeedbackState>()((set) => ({
       status: 'PENDING',
     }),
 
-  setDone: (original, revised) =>
+  setDone: (feedId, revised) =>
     set({
-      originalText: original,
+      feedbackId: feedId,
       revisedText: revised,
       status: 'DONE',
       isSplitView: true,
@@ -62,5 +61,13 @@ export const useFeedbackStore = create<FeedbackState>()((set) => ({
     set({
       questions: null,
       status: 'ANSWERING',
+    }),
+
+  resetFeedback: () =>
+    set({
+      status: 'IDLE',
+      isSplitView: false,
+      feedbackId: '',
+      revisedText: null,
     }),
 }));

--- a/src/store/FeedbackStore.ts
+++ b/src/store/FeedbackStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { FeedbackStatus } from '@/mocks/types';
 import type { Question } from '@/types/document';
+import * as Y from 'yjs';
 
 interface FeedbackState {
   isSplitView: boolean;
@@ -10,22 +11,26 @@ interface FeedbackState {
   originalText: string;
   questions: Question[] | null;
   revisedText: string | Uint8Array;
+  ydoc: Y.Doc | null;
   setPending: (docId: string, feedId: string) => void;
   setDone: (original: string, revised: string | Uint8Array) => void;
   acceptFeedback: () => void;
   setAnswering: () => void;
   setQuestioning: (questions: Question[]) => void;
+  setYdoc: (doc: Y.Doc) => void;
 }
 
 export const useFeedbackStore = create<FeedbackState>()((set) => ({
   isSplitView: false,
   documentId: '',
   feedbackId: '',
-  status: 'IDLE',
+  status: 'DONE',
   originalText: '',
   revisedText: '',
   questions: null,
+  ydoc: null,
 
+  setYdoc: (doc) => set({ ydoc: doc }),
   setPending: (docId, feedId) =>
     set({
       documentId: docId,


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- Closes #58


<br>

## 📝 작업 내용
- FeedbackStore에서 관리할 상태 추가 (questions, setAnswering, setQuestioning)
- FeedbackStatus에 IDLE, QUESTIONING, ANSWERING 추가
- MainContent.tsx에 피드백 status에 따른 UI 추가
- AI가 질문하는 QuestionPanel.tsx 생성(미완)
- 사이드바에 문서 추가 임시 코드 작성
- FeedbackStore에서 관리했던 originalText -> ydoc로 변경
- setYdoc 함수를 통해 메인 에디터에 작성된 내용을 저장소의 ydoc에 저장
- 에러 발생 시 상태 초기화하는 resetFeedback 함수 생성
- 피드백 이벤트에 맞는 웹소켓 기능 구현
- 다른 사람 화면에도 스플릿뷰가 열리게 setDone 함수 useFeedback -> useCollabEditor로 이동
- VersionPanel에 들어갈 ydoc, aiDoc 모두 yjs 문서라서 yjs 이해할 수 있는 블록노트 사용(읽기 전용)
- SplitView에서 소켓으로 전달받은 revisedText를 블록노트 에디터가 이해할 수 있도록 독립된 Y.Doc 객체로 변환


<br>

## 🖼️ 스크린샷 (선택)



<br>

## 테스트 및 검증 내용
> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.


<br>

## 🤔 주요 고민과 해결 과정

> 작성 양식
> - [트러블 슈팅1](링크)
> 혹은 직접 작성


<br>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<br>

## 🧩 참고 사항 (선택)

> 공유하고 싶은 링크나 게시글 등