### PR TITLE
Hotfix: 초대 로직을 백엔드 스펙에 맞춤

### DIFF
--- a/docs/invitation-flow.md
+++ b/docs/invitation-flow.md
@@ -1,0 +1,176 @@
+# 초대 흐름 명세 (백엔드 기준)
+
+> 최종 수정: 2026-06-04  
+> 대상 독자: 프론트엔드 개발자
+
+---
+
+## 1. 변경 사항 요약
+
+초대 수락 전에는 멤버 목록에 해당 사용자가 노출되지 않습니다.
+
+| 이전                                                        | 현재                                               |
+| ----------------------------------------------------------- | -------------------------------------------------- |
+| 초대 발송 시 멤버 목록에 `status: "PENDING"` 항목 즉시 노출 | 초대 발송 시 멤버 목록에 아무 변화 없음            |
+| 수락 후 `status: "ACTIVE"` 로 전환                          | 수락 후 멤버 목록에 처음 등장 (`status: "ACTIVE"`) |
+
+`GET /api/teamspaces/{teamspaceId}/members`는 이제 실제로 팀스페이스에 가입이 완료된 멤버만 반환합니다.
+
+---
+
+## 2. 초대 발송
+
+### 엔드포인트
+
+| 방법                   | URL                                                 | 설명                                        |
+| ---------------------- | --------------------------------------------------- | ------------------------------------------- |
+| 단건 (기존)            | `POST /api/invitations`                             | body: `teamspaceId`, `inviteeEmail`, `role` |
+| 단건 (팀스페이스 경로) | `POST /api/teamspaces/{teamspaceId}/members/invite` | body: `email` / 역할은 MEMBER 고정          |
+| 일괄 (최대 8명)        | `POST /api/teamspaces/{teamspaceId}/invitations`    | body: `emails[]`                            |
+
+### 발송 후 서버 동작
+
+1. 중복·권한 검증 후 `invitation` 테이블에 행 생성 (status = `PENDING`)
+2. 초대 토큰(`UUID`)을 포함한 링크를 수신자 이메일로 발송
+   - 링크 형태: `https://{backendDomain}/api/invitations/accept?token={UUID}`
+   - 유효 시간: **48시간**
+3. 메일 발송 실패는 서버 로그만 남기고 API는 성공으로 응답 (메일 서버 장애가 초대 자체를 막지 않음)
+
+### 초대 불가 케이스 (API 에러 응답)
+
+| 에러 코드                 | 원인                                   |
+| ------------------------- | -------------------------------------- |
+| `ALREADY_MEMBER`          | 이미 팀스페이스에 가입된 사용자        |
+| `ALREADY_INVITED`         | 해당 이메일로 PENDING 초대가 이미 존재 |
+| `INSUFFICIENT_PERMISSION` | VIEWER 권한으로 초대 시도              |
+| `NOT_TEAMSPACE_OWNER`     | 일괄 초대를 OWNER 외 역할이 시도       |
+| `INVITATION_001`          | 일괄 초대 8명 초과                     |
+
+---
+
+## 3. 수락 흐름
+
+이메일 링크는 **백엔드 URL**을 직접 가리킵니다. 브라우저가 이 URL에 접근하면 백엔드가 상황에 따라 프론트엔드로 리다이렉트합니다.
+
+### 3-A. 로그인 상태에서 링크 클릭
+
+```
+브라우저
+  → GET https://{backendDomain}/api/invitations/accept?token={UUID}
+      (access_token 쿠키 존재)
+  ← 302 Location: https://{frontendDomain}/main/{docId}   (성공)
+  ← 302 Location: https://{frontendDomain}/              (이미 멤버)
+  ← 302 Location: https://{frontendDomain}/?error={CODE} (그 외 오류)
+```
+
+성공 시 `access_token` / `refresh_token` 쿠키는 이미 유효하므로 추가 인증 없이 문서 페이지에 진입 가능합니다.
+
+### 3-B. 비로그인 상태에서 링크 클릭 (신규 또는 기존 회원)
+
+```
+브라우저
+  → GET https://{backendDomain}/api/invitations/accept?token={UUID}
+      (access_token 쿠키 없음)
+  ← 302 Location: /oauth2/authorization/github
+     + Set-Cookie: pending_invite_token={UUID}; HttpOnly; Path=/; MaxAge=600
+                   (SameSite=None;Secure — 프로덕션 / Lax — 개발)
+
+브라우저
+  → GitHub OAuth 인증 진행
+
+GitHub
+  → GET https://{backendDomain}/login/oauth2/code/github?code=...
+      (pending_invite_token 쿠키 자동 첨부)
+
+백엔드 OAuth 콜백 처리
+  → JWT 발급 (access_token, refresh_token 쿠키 설정)
+  → pending_invite_token 쿠키 감지 → 초대 자동 수락
+  → pending_invite_token 쿠키 삭제 (MaxAge=0)
+  ← 302 Location: https://{frontendDomain}/main/{docId}   (성공)
+  ← 302 Location: https://{frontendDomain}/?error={CODE}  (수락 실패)
+  ← 302 Location: https://{frontendDomain}/               (초대 처리 없이 로그인만 성공한 경우)
+```
+
+#### pending_invite_token 쿠키 특성
+
+- **이름**: `pending_invite_token`
+- **값**: 초대 토큰 UUID
+- **유효 시간**: 10분 (OAuth 플로우를 완료하기 충분한 시간)
+- **범위**: 백엔드 도메인 전체 (`Path=/`)
+- 이 쿠키는 백엔드 도메인에만 존재하며 프론트엔드에서 직접 읽을 필요 없음
+
+#### 신규 회원 처리
+
+GitHub OAuth 로그인 시 Aidea에 가입 이력이 없으면 자동으로 계정이 생성됩니다. 이후 초대 수락 → 멤버 등록까지 동일한 흐름으로 처리됩니다.
+
+---
+
+## 4. 수락 후 JWT 쿠키
+
+OAuth 콜백(3-B 흐름) 또는 기존 로그인 상태(3-A 흐름) 모두, 프론트엔드에 도달하는 시점에 아래 두 쿠키가 설정되어 있습니다.
+
+| 쿠키 이름       | 용도                | 유효 시간 | 특성                        |
+| --------------- | ------------------- | --------- | --------------------------- |
+| `access_token`  | API 요청 인증       | 30분      | HttpOnly, SameSite=None/Lax |
+| `refresh_token` | access_token 재발급 | 14일      | HttpOnly, SameSite=None/Lax |
+
+프론트엔드는 API 호출 시 이 쿠키를 자동으로 브라우저가 첨부합니다 (`credentials: 'include'` 필요). 쿠키 값을 JavaScript에서 직접 읽을 수 없습니다(HttpOnly).
+
+---
+
+## 5. 수락 실패 에러 코드
+
+3-A / 3-B 양쪽에서 실패 시 프론트엔드는 `/?error={CODE}` 형태의 쿼리 파라미터를 받습니다.
+
+| `error` 값             | 원인                                                           | 권장 안내 메시지                                                   |
+| ---------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `INVITATION_EXPIRED`   | 링크 48시간 초과 또는 이미 수락됨                              | "초대 링크가 만료되었습니다. 초대를 다시 요청하세요."              |
+| `INVITATION_NOT_FOUND` | 유효하지 않은 토큰 또는 초대받은 이메일과 다른 계정으로 로그인 | "유효하지 않은 초대입니다. 초대받은 이메일 계정으로 로그인하세요." |
+| `ALREADY_MEMBER`       | 이미 팀스페이스 멤버                                           | "이미 팀원입니다."                                                 |
+| `INTERNAL_ERROR`       | 서버 내부 오류                                                 | "오류가 발생했습니다. 잠시 후 다시 시도하세요."                    |
+
+`/?error=` 파라미터가 존재하는 경우 홈 화면 진입 시 적절한 토스트 또는 모달로 사용자에게 안내하는 것을 권장합니다.
+
+---
+
+## 6. SPA에서 토큰 직접 수락 (선택적 흐름)
+
+이미 로그인된 SPA 환경에서 초대 토큰을 직접 처리하고 싶다면 POST 엔드포인트를 사용할 수 있습니다.
+
+```
+POST /api/invitations/accept
+Content-Type: application/json
+
+{ "token": "{UUID}" }
+```
+
+**응답**
+
+```json
+{
+  "message": "팀스페이스에 참여하였습니다.",
+  "data": { "docId": "{documentId 또는 빈 문자열}" }
+}
+```
+
+`docId`가 비어 있으면 해당 팀스페이스에 문서가 없는 상태입니다. 이 엔드포인트는 로그인 상태에서만 동작하며, 미로그인 시 401 응답합니다.
+
+---
+
+## 7. 초대 취소
+
+OWNER 권한이 있는 멤버만 가능합니다.
+
+```
+DELETE /api/teamspaces/{teamspaceId}/invitations/{invitationId}
+```
+
+`invitationId`는 초대 발송 API 응답이나 별도의 pending 초대 목록 조회가 있다면 거기서 얻어야 합니다. 현재 멤버 목록 API(`GET /api/teamspaces/{id}/members`)에서는 pending 항목이 노출되지 않으므로, 초대 취소 UI가 필요하다면 백엔드에 pending 초대 목록 API 추가를 요청하거나 일괄 초대 응답 결과를 프론트엔드 상태로 유지하는 방식을 사용하세요.
+
+---
+
+## 8. 알려진 제약
+
+- 초대받은 이메일과 다른 GitHub 계정으로 로그인하면 `INVITATION_NOT_FOUND` 오류가 발생합니다. 이 경우 에러 메시지를 "초대받은 이메일 계정으로 로그인하세요"로 안내하는 것이 적절합니다.
+- `pending_invite_token` 쿠키 유효 시간은 10분이므로 OAuth 인증이 10분 이상 지연되면 토큰이 소실되어 로그인은 성공하지만 초대 수락은 되지 않습니다. 이때 사용자는 `/?error` 없이 `/`로 리다이렉트됩니다.
+- 팀스페이스에 문서가 없는 경우 수락 성공 후 `/`로 리다이렉트됩니다 (`docId`가 없음).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,21 @@
 import { useEffect } from 'react';
-import { Navigate, Route, Routes } from 'react-router';
+import { Navigate, Route, Routes, useSearchParams } from 'react-router';
 import { useAuth } from '@/shared/useAuth';
 import { useAuthStore } from '@/store/authStore';
+import { useToastStore } from '@/store/toastStore';
 import { apiClient } from '@/shared/apiClient';
 import LandingPage from '@/pages/LandingPage';
 import MainPage from '@/pages/MainPage';
 import CreatePage from '@/pages/CreatePage';
 import ToastContainer from '@/components/ui/ToastContainer';
+
+const ACCEPT_ERROR_MESSAGES: Record<string, string> = {
+  INVITATION_EXPIRED: '초대 링크가 만료되었습니다. 초대를 다시 요청하세요.',
+  INVITATION_NOT_FOUND: '유효하지 않은 초대입니다.',
+  INVITATION_EMAIL_MISMATCH: '초대받은 이메일 계정으로 로그인하세요.',
+  ALREADY_MEMBER: '이미 팀원입니다.',
+  INTERNAL_ERROR: '오류가 발생했습니다. 잠시 후 다시 시도하세요.',
+};
 
 function AuthInitializer({ children }: { children: React.ReactNode }) {
   const { setAuthenticated, setLoading } = useAuthStore();
@@ -24,6 +33,24 @@ function AuthInitializer({ children }: { children: React.ReactNode }) {
 
 function RootRoute() {
   const { isAuthenticated, isLoading } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    const errorCode = searchParams.get('error');
+    if (!errorCode) return;
+
+    const message = ACCEPT_ERROR_MESSAGES[errorCode] ?? '초대 처리 중 오류가 발생했습니다.';
+    useToastStore.getState().addToast({ type: 'error', message });
+
+    setSearchParams(
+      (prev) => {
+        prev.delete('error');
+        return prev;
+      },
+      { replace: true }
+    );
+  }, []);
+
   if (isLoading) return null;
   if (!isAuthenticated) return <LandingPage />;
   return <MainPage />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Navigate, Route, Routes, useSearchParams } from 'react-router';
+import { Navigate, Route, Routes, useSearchParams, useNavigate } from 'react-router';
 import { useAuth } from '@/shared/useAuth';
 import { useAuthStore } from '@/store/authStore';
 import { useToastStore } from '@/store/toastStore';
@@ -7,6 +7,7 @@ import { apiClient } from '@/shared/apiClient';
 import LandingPage from '@/pages/LandingPage';
 import MainPage from '@/pages/MainPage';
 import CreatePage from '@/pages/CreatePage';
+import InvitePage from '@/pages/InvitePage';
 import ToastContainer from '@/components/ui/ToastContainer';
 
 const ACCEPT_ERROR_MESSAGES: Record<string, string> = {
@@ -34,6 +35,7 @@ function AuthInitializer({ children }: { children: React.ReactNode }) {
 function RootRoute() {
   const { isAuthenticated, isLoading } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const errorCode = searchParams.get('error');
@@ -50,6 +52,23 @@ function RootRoute() {
       { replace: true }
     );
   }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    const token = localStorage.getItem('pending_invite_token');
+    if (!token) return;
+
+    localStorage.removeItem('pending_invite_token');
+    apiClient
+      .post('/api/invitations/accept', { token })
+      .then((res) => {
+        const { docId } = res.data.data as { docId: string };
+        if (docId) navigate(`/main/${docId}`, { replace: true });
+      })
+      .catch(() => {
+        // 에러 toast는 apiClient 인터셉터 처리
+      });
+  }, [isAuthenticated]);
 
   if (isLoading) return null;
   if (!isAuthenticated) return <LandingPage />;
@@ -85,6 +104,8 @@ function App() {
             </ProtectedRoute>
           }
         />
+
+        <Route path="/invite" element={<InvitePage />} />
       </Routes>
       <ToastContainer />
     </AuthInitializer>

--- a/src/components/backlog/AssigneeSelect.tsx
+++ b/src/components/backlog/AssigneeSelect.tsx
@@ -14,7 +14,7 @@ export default function AssigneeSelect({ value, members, onChange }: AssigneeSel
   const popoverRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const activeMembers = members.filter((m) => m.status === 'ACTIVE' && m.userId !== null);
+  const activeMembers = members;
   const selected = activeMembers.find((m) => m.userId === value) ?? null;
 
   const filtered = activeMembers.filter((m) => {

--- a/src/components/main/MemberModal.tsx
+++ b/src/components/main/MemberModal.tsx
@@ -3,7 +3,7 @@ import { apiClient } from '@/shared/apiClient';
 import { useTeamspaceStore } from '@/store/teamspaceStore';
 import UserAvatar from '@/components/ui/UserAvatar';
 import Button from '@/components/ui/Button';
-import type { MemberInfo } from '@/types/api';
+import type { MemberInfo, PendingInvitation, InviteResponse } from '@/types/api';
 
 interface MemberModalProps {
   isMemberModalOpen: boolean;
@@ -13,6 +13,7 @@ interface MemberModalProps {
 export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: MemberModalProps) {
   const { currentTeamspaceId } = useTeamspaceStore();
   const [members, setMembers] = useState<MemberInfo[]>([]);
+  const [pendingInvitations, setPendingInvitations] = useState<PendingInvitation[]>([]);
   const [email, setEmail] = useState('');
 
   const fetchMembers = useCallback(() => {
@@ -28,11 +29,12 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
 
   const handleInvite = async () => {
     if (!email.trim() || !currentTeamspaceId) return;
-    await apiClient.post(`/api/teamspaces/${currentTeamspaceId}/members/invite`, {
+    const res = await apiClient.post(`/api/teamspaces/${currentTeamspaceId}/members/invite`, {
       email: email.trim(),
     });
+    const { invitationId } = res.data.data as InviteResponse;
+    setPendingInvitations((prev) => [...prev, { invitationId, email: email.trim() }]);
     setEmail('');
-    fetchMembers();
   };
 
   const handleRemoveMember = async (memberId: string) => {
@@ -44,7 +46,7 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
   const handleCancelInvitation = async (invitationId: string) => {
     if (!currentTeamspaceId) return;
     await apiClient.delete(`/api/teamspaces/${currentTeamspaceId}/invitations/${invitationId}`);
-    fetchMembers();
+    setPendingInvitations((prev) => prev.filter((inv) => inv.invitationId !== invitationId));
   };
 
   if (!isMemberModalOpen) return null;
@@ -64,12 +66,12 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
         <div className="text-xs text-gray-500">멤버</div>
         <div className="flex flex-col gap-3">
           {members.map((member) => (
-            <div key={member.email} className="flex justify-between items-center">
+            <div key={member.userId} className="flex justify-between items-center">
               <div className="flex gap-3 items-center">
-                <UserAvatar name={member.name ?? member.email} imageUrl={member.profileImageUrl} />
+                <UserAvatar name={member.name} imageUrl={member.profileImageUrl} />
                 <div>
                   <div className="font-medium text-sm">
-                    {member.status === 'PENDING' ? '초대 대기 중' : member.name}
+                    {member.name}
                     {member.role === 'OWNER' && (
                       <span className="ml-1 text-xs text-primary">(방장)</span>
                     )}
@@ -78,16 +80,7 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
                 </div>
               </div>
 
-              {member.status === 'PENDING' && member.invitationId && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => handleCancelInvitation(member.invitationId!)}
-                >
-                  초대 취소
-                </Button>
-              )}
-              {member.status === 'ACTIVE' && member.role !== 'OWNER' && (
+              {member.role !== 'OWNER' && (
                 <Button
                   variant="secondary"
                   size="sm"
@@ -100,6 +93,32 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
             </div>
           ))}
         </div>
+
+        {pendingInvitations.length > 0 && (
+          <>
+            <div className="text-xs text-gray-500">초대 대기 중</div>
+            <div className="flex flex-col gap-3">
+              {pendingInvitations.map((inv) => (
+                <div key={inv.invitationId} className="flex justify-between items-center">
+                  <div className="flex gap-3 items-center">
+                    <UserAvatar name={inv.email} imageUrl={null} />
+                    <div>
+                      <div className="font-medium text-sm text-gray-400">초대 대기 중</div>
+                      <div className="text-xs text-gray-500">{inv.email}</div>
+                    </div>
+                  </div>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleCancelInvitation(inv.invitationId)}
+                  >
+                    초대 취소
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
 
         <hr className="h-px border-none" />
 

--- a/src/components/ui/AvatarStack.tsx
+++ b/src/components/ui/AvatarStack.tsx
@@ -8,9 +8,8 @@ interface AvatarStackProps {
 }
 
 export default function AvatarStack({ members, max = 5, size = 32 }: AvatarStackProps) {
-  const active = members.filter((m) => m.status === 'ACTIVE');
-  const visible = active.slice(0, max);
-  const overflow = active.length - visible.length;
+  const visible = members.slice(0, max);
+  const overflow = members.length - visible.length;
 
   return (
     <div className="flex items-center">

--- a/src/pages/InvitePage.tsx
+++ b/src/pages/InvitePage.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router';
+import { useAuth } from '@/shared/useAuth';
+import { apiClient } from '@/shared/apiClient';
+import { useToastStore } from '@/store/toastStore';
+
+export default function InvitePage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading, login } = useAuth();
+  const token = searchParams.get('token');
+
+  useEffect(() => {
+    if (!token) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: '유효하지 않은 초대 링크입니다.' });
+      navigate('/', { replace: true });
+      return;
+    }
+
+    if (isLoading) return;
+
+    if (isAuthenticated) {
+      apiClient
+        .post('/api/invitations/accept', { token })
+        .then((res) => {
+          const { docId } = res.data.data as { docId: string };
+          navigate(docId ? `/main/${docId}` : '/', { replace: true });
+        })
+        .catch(() => {
+          navigate('/', { replace: true });
+        });
+    } else {
+      localStorage.setItem('pending_invite_token', token);
+      login();
+    }
+  }, [isLoading, isAuthenticated, token, navigate, login]);
+
+  return null;
+}

--- a/src/shared/apiClient.ts
+++ b/src/shared/apiClient.ts
@@ -8,6 +8,8 @@ const INVITATION_ERROR_MESSAGES: Record<string, string> = {
   INSUFFICIENT_PERMISSION: '초대 권한이 없습니다.',
   NOT_TEAMSPACE_OWNER: '일괄 초대는 OWNER만 가능합니다.',
   INVITATION_001: '초대는 최대 8명까지 가능합니다.',
+  INVITATION_EXPIRED: '초대 링크가 만료되었습니다. 초대를 다시 요청하세요.',
+  INVITATION_NOT_FOUND: '유효하지 않은 초대입니다.',
 };
 
 // 목 모드(VITE_USE_REAL_AUTH !== 'true')에서는 빈 baseURL → MSW가 동일 오리진 요청을 인터셉트

--- a/src/shared/apiClient.ts
+++ b/src/shared/apiClient.ts
@@ -2,6 +2,14 @@ import axios from 'axios';
 import { useAuthStore } from '@/store/authStore';
 import { useToastStore } from '@/store/toastStore';
 
+const INVITATION_ERROR_MESSAGES: Record<string, string> = {
+  ALREADY_MEMBER: '이미 팀스페이스에 가입된 사용자입니다.',
+  ALREADY_INVITED: '이미 초대가 발송된 이메일입니다.',
+  INSUFFICIENT_PERMISSION: '초대 권한이 없습니다.',
+  NOT_TEAMSPACE_OWNER: '일괄 초대는 OWNER만 가능합니다.',
+  INVITATION_001: '초대는 최대 8명까지 가능합니다.',
+};
+
 // 목 모드(VITE_USE_REAL_AUTH !== 'true')에서는 빈 baseURL → MSW가 동일 오리진 요청을 인터셉트
 // 실제 모드에서는 VITE_API_BASE_URL 사용
 const baseURL =
@@ -36,9 +44,9 @@ apiClient.interceptors.response.use(
     if (error.response?.status !== 401 || originalRequest._retry) {
       // 401은 refresh 흐름이 처리. 그 외 서버/네트워크 에러는 toast로 표시.
       if (error.response?.status !== 401) {
-        const message =
-          (error.response?.data as { message?: string })?.message ??
-          '서버와 통신 중 오류가 발생했습니다.';
+        const data = error.response?.data as { message?: string; code?: string } | undefined;
+        const customMessage = data?.code ? INVITATION_ERROR_MESSAGES[data.code] : undefined;
+        const message = customMessage ?? data?.message ?? '서버와 통신 중 오류가 발생했습니다.';
         useToastStore.getState().addToast({ type: 'error', message });
       }
       return Promise.reject(error);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,13 +18,22 @@ export interface TokenResponse {
 }
 
 export interface MemberInfo {
-  userId: number | null;
-  name: string | null;
+  userId: number;
+  name: string;
   email: string;
   role: 'OWNER' | 'MEMBER' | 'VIEWER';
-  status: 'ACTIVE' | 'PENDING';
   profileImageUrl: string | null;
-  invitationId: string | null;
+}
+
+export interface PendingInvitation {
+  invitationId: string;
+  email: string;
+}
+
+export interface InviteResponse {
+  invitationId: string;
+  email: string;
+  role: 'OWNER' | 'MEMBER' | 'VIEWER';
 }
 
 export interface DocumentSummary {
@@ -58,12 +67,4 @@ export interface TeamspaceDetail {
 export interface FeedbackResponse {
   feedbackId: string;
   status: FeedbackStatus;
-}
-
-export interface Invitation {
-  invitationId: string;
-  teamspaceId: string;
-  email: string;
-  token: string;
-  status: 'PENDING';
 }


### PR DESCRIPTION
## 📝 작업 내용

백엔드가 멤버 목록 API 스펙을 변경(ACTIVE 멤버만 반환)함에 따라 프론트엔드 초대 로직을 전면 수정했습니다.

주요 변경 사항:
- MemberInfo 타입에서 status/invitationId 제거, ACTIVE 멤버만 반환하는 새 스펙에 맞춤
- PendingInvitation, InviteResponse 타입 추가
- MemberModal: 초대 발송 응답에서 invitationId를 로컬 상태로 관리해 초대 대기/취소 UI 유지
- apiClient 인터셉터에 초대 에러 코드(ALREADY_MEMBER 등) 커스텀 메시지 매핑 추가
- App.tsx RootRoute에서 /?error= 쿼리 파라미터 감지 후 toast 표시 (초대 링크 클릭 시 에러 처리)
- AssigneeSelect, AvatarStack에서 불필요해진 status === 'ACTIVE' 필터 제거

<br>

## 테스트 및 검증 내용

- 신규 초대 발송 후 초대 대기 UI가 노출되는지 확인
- 이미 멤버인 이메일 초대 시 ALREADY_MEMBER 커스텀 에러 토스트 노출 확인
- 초대 링크 클릭 시 에러 케이스(만료, 중복 등)에서 /?error= 파라미터가 올바르게 처리되는지 확인

<br>

## 🤔 주요 고민과 해결 과정

**[초대 대기 상태 UI 유지 문제]**

백엔드가 ACTIVE 멤버만 반환하도록 변경되면서 invitationId를 서버에서 받을 수 없게 됨.
초대 발송 시 응답으로 받은 invitationId를 MemberModal의 로컬 상태(pendingInvitations)로 관리해
페이지 내 초대 취소 UI를 유지하는 방식으로 해결.

