### PR TITLE
Hotfix: 프롬프트 고도화 및 레이아웃 깨짐 현상 해결

### DIFF
--- a/src/components/document/CollaborativeEditor.tsx
+++ b/src/components/document/CollaborativeEditor.tsx
@@ -3,6 +3,8 @@ import { useEffect } from 'react';
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCollabEditor } from '@/hooks/useCollabEditor';
 import { useDocumentEditorStore } from '@/store/documentEditorStore';
+import { useTeamspaceStore } from '@/store/teamspaceStore';
+import DraftQuestionPanel from '@/components/main/DraftQuestionPanel';
 
 interface Props {
   docId: string;
@@ -12,9 +14,38 @@ interface Props {
   token: string;
 }
 
+function LoadingSpinner({ message }: { message: string }) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/75 z-10 rounded-lg">
+      <svg
+        className="animate-spin h-7 w-7 text-blue-500"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        />
+      </svg>
+      <p className="text-sm font-medium text-gray-600">{message}</p>
+    </div>
+  );
+}
+
 function CollaborativeEditor({ docId, editable, isAiDraftGenerating = false, user, token }: Props) {
   const { editor } = useCollabEditor({ docId, editable, user, token });
   const setEditor = useDocumentEditorStore((state) => state.setEditor);
+  const draftQA = useTeamspaceStore((state) => state.draftQA);
 
   useEffect(() => {
     setEditor(editor);
@@ -22,37 +53,21 @@ function CollaborativeEditor({ docId, editable, isAiDraftGenerating = false, use
     return () => setEditor(null);
   }, [editor, setEditor]);
 
+  // IDEA 초안 Q&A 흐름의 세부 단계 — 같은 문서에 대한 draftQA가 있을 때만 의미가 있다.
+  const isQuestioningThisDoc = draftQA?.documentId === docId && draftQA.status === 'QUESTIONING';
+  const isAnsweringThisDoc = draftQA?.documentId === docId && draftQA.status === 'ANSWERING';
+
   return (
     <div className="relative">
       <div inert={isAiDraftGenerating || undefined}>
         <BlockNoteView editor={editor} theme="light" />
       </div>
-      {isAiDraftGenerating && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/75 z-10 rounded-lg">
-          <svg
-            className="animate-spin h-7 w-7 text-blue-500"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            />
-          </svg>
-          <p className="text-sm font-medium text-gray-600">
-            AI 초안을 생성하고 있습니다. 잠시 후 자동으로 반영됩니다.
-          </p>
-        </div>
+      {isQuestioningThisDoc && <DraftQuestionPanel documentId={docId} />}
+      {!isQuestioningThisDoc && isAnsweringThisDoc && (
+        <LoadingSpinner message="답변을 반영해 초안을 다시 작성하고 있어요. 시간이 조금 더 걸릴 수 있어요." />
+      )}
+      {!isQuestioningThisDoc && !isAnsweringThisDoc && isAiDraftGenerating && (
+        <LoadingSpinner message="AI 초안을 생성하고 있습니다. 잠시 후 자동으로 반영됩니다." />
       )}
     </div>
   );

--- a/src/components/document/CollaborativeEditor.tsx
+++ b/src/components/document/CollaborativeEditor.tsx
@@ -58,7 +58,7 @@ function CollaborativeEditor({ docId, editable, isAiDraftGenerating = false, use
   const isAnsweringThisDoc = draftQA?.documentId === docId && draftQA.status === 'ANSWERING';
 
   return (
-    <div className="relative">
+    <div className="relative min-h-[calc(100vh-160px)]">
       <div inert={isAiDraftGenerating || undefined}>
         <BlockNoteView editor={editor} theme="light" />
       </div>

--- a/src/components/main/DraftQuestionPanel.tsx
+++ b/src/components/main/DraftQuestionPanel.tsx
@@ -81,22 +81,24 @@ export default function DraftQuestionPanel({ documentId }: DraftQuestionPanelPro
   }
 
   return (
-    <div className="absolute inset-0 z-20 flex flex-col gap-4 bg-white overflow-y-auto p-6">
-      <div className="bg-[#F4F0FF] rounded-xl p-4 border border-purple-50">
-        <div className="flex items-center gap-2 text-[#7C3AED] font-bold text-base mb-1.5">
-          <span className="text-xl">✦</span> Aidea
+    <div className="absolute inset-0 z-20 flex flex-col bg-white">
+      <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-4">
+        <div className="bg-[#F4F0FF] rounded-xl p-4 border border-purple-50">
+          <div className="flex items-center gap-2 text-[#7C3AED] font-bold text-base mb-1.5">
+            <span className="text-xl">✦</span> Aidea
+          </div>
+          <div className="text-gray-800 text-sm leading-relaxed">
+            <p>더 좋은 초안을 만들기 위해 아이디어를 조금 더 구체화하고 싶어요.</p>
+            <p className="font-medium text-[#7C3AED] mt-1">
+              몇 가지만 여쭤봐도 될까요? 선택하거나 직접 입력하실 수 있어요.
+            </p>
+          </div>
         </div>
-        <div className="text-gray-800 text-sm leading-relaxed">
-          <p>더 좋은 초안을 만들기 위해 아이디어를 조금 더 구체화하고 싶어요.</p>
-          <p className="font-medium text-[#7C3AED] mt-1">
-            몇 가지만 여쭤봐도 될까요? 선택하거나 직접 입력하실 수 있어요.
-          </p>
-        </div>
+
+        <QuestionList questions={questions} answers={answers} onSelect={handleSelect} />
       </div>
 
-      <QuestionList questions={questions} answers={answers} onSelect={handleSelect} />
-
-      <div className="mt-4 flex flex-col items-center gap-3 pb-8">
+      <div className="shrink-0 flex flex-col items-center gap-3 px-6 py-5 border-t border-gray-100 bg-white">
         <Button
           onClick={handleSubmit}
           disabled={submitting}

--- a/src/components/main/DraftQuestionPanel.tsx
+++ b/src/components/main/DraftQuestionPanel.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import Button from '../ui/Button';
+import QuestionList from './QuestionList';
+import { useTeamspaceStore } from '@/store/teamspaceStore';
+import useDraft from '@/hooks/useDraft';
+
+interface DraftQuestionPanelProps {
+  documentId: string;
+}
+
+// IDEA 초안 생성 1차 호출 후 받는 "구체화 질문" 화면.
+// 구조(id/section/text/options[])는 feedback:questioning과 동일하므로 QuestionList를 공용으로 사용한다.
+export default function DraftQuestionPanel({ documentId }: DraftQuestionPanelProps) {
+  const draftQA = useTeamspaceStore((state) => state.draftQA);
+  const setDraftAnswering = useTeamspaceStore((state) => state.setDraftAnswering);
+  const { submitDraftAnswers, skipDraftQuestions } = useDraft();
+
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const isQuestioningForThisDoc =
+    draftQA?.status === 'QUESTIONING' && draftQA.documentId === documentId;
+
+  const handleSelect = (questionId: string, value: string) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+  };
+
+  const handleSubmit = async () => {
+    if (!draftQA?.questions || submitting) return;
+    setSubmitting(true);
+    try {
+      const answerList = draftQA.questions.map((q) => ({
+        questionId: q.id,
+        value: answers[q.id] ?? '',
+      }));
+      await submitDraftAnswers(draftQA.draftId, answerList);
+      setDraftAnswering();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSkip = async () => {
+    if (!draftQA || submitting) return;
+    setSubmitting(true);
+    try {
+      await skipDraftQuestions(draftQA.draftId);
+      setDraftAnswering();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isQuestioningForThisDoc) return null;
+
+  const { questions } = draftQA;
+
+  // 새로고침/재접속 시: doc:init.activeDraft에는 questions가 포함되지 않으므로(알려진 백엔드 갭)
+  // 질문 화면을 정상적으로 그릴 수 없다 — 안내와 건너뛰기 옵션을 제공한다.
+  if (!questions) {
+    return (
+      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-white p-6 text-center">
+        <div className="bg-[#F4F0FF] rounded-xl p-4 border border-purple-50 max-w-md">
+          <div className="flex items-center gap-2 text-[#7C3AED] font-bold text-base mb-1.5 justify-center">
+            <span className="text-xl">✦</span> Aidea
+          </div>
+          <p className="text-gray-800 text-sm leading-relaxed">
+            질문 내용을 불러올 수 없습니다. 잠시 후 다시 시도해주세요.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSkip}
+          disabled={submitting}
+          className="text-gray-400 text-sm font-medium hover:text-gray-600 transition-colors disabled:opacity-60"
+        >
+          질문 건너뛰고 바로 초안 만들기
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="absolute inset-0 z-20 flex flex-col gap-4 bg-white overflow-y-auto p-6">
+      <div className="bg-[#F4F0FF] rounded-xl p-4 border border-purple-50">
+        <div className="flex items-center gap-2 text-[#7C3AED] font-bold text-base mb-1.5">
+          <span className="text-xl">✦</span> Aidea
+        </div>
+        <div className="text-gray-800 text-sm leading-relaxed">
+          <p>더 좋은 초안을 만들기 위해 아이디어를 조금 더 구체화하고 싶어요.</p>
+          <p className="font-medium text-[#7C3AED] mt-1">
+            몇 가지만 여쭤봐도 될까요? 선택하거나 직접 입력하실 수 있어요.
+          </p>
+        </div>
+      </div>
+
+      <QuestionList questions={questions} answers={answers} onSelect={handleSelect} />
+
+      <div className="mt-4 flex flex-col items-center gap-3 pb-8">
+        <Button
+          onClick={handleSubmit}
+          disabled={submitting}
+          className="w-full max-w-lg py-3.5 bg-blue-600 text-white rounded-xl font-bold text-base hover:bg-blue-700 transition-colors shadow-md disabled:opacity-60"
+        >
+          답변하고 초안 만들기
+        </Button>
+        <button
+          type="button"
+          onClick={handleSkip}
+          disabled={submitting}
+          className="text-gray-400 text-sm font-medium hover:text-gray-600 transition-colors disabled:opacity-60"
+        >
+          건너뛰고 바로 초안 만들기
+        </button>
+        <p className="text-gray-400 text-xs text-center font-medium">
+          모든 질문에 답하지 않아도 초안을 받을 수 있어요.
+          <br />
+          답변할수록 더 정확한 초안을 드릴 수 있습니다.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main/DraftQuestionPanel.tsx
+++ b/src/components/main/DraftQuestionPanel.tsx
@@ -55,8 +55,6 @@ export default function DraftQuestionPanel({ documentId }: DraftQuestionPanelPro
 
   const { questions } = draftQA;
 
-  // 새로고침/재접속 시: doc:init.activeDraft에는 questions가 포함되지 않으므로(알려진 백엔드 갭)
-  // 질문 화면을 정상적으로 그릴 수 없다 — 안내와 건너뛰기 옵션을 제공한다.
   if (!questions) {
     return (
       <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-white p-6 text-center">

--- a/src/components/main/QuestionList.tsx
+++ b/src/components/main/QuestionList.tsx
@@ -1,0 +1,111 @@
+import type { Question } from '@/types/document';
+
+interface QuestionListProps {
+  questions: Question[];
+  answers: Record<string, string>;
+  onSelect: (questionId: string, value: string) => void;
+}
+
+// feedback:questioning / draft:questioning 공용 — 질문 목록 렌더링 (id/section/text/options[] 구조)
+export default function QuestionList({ questions, answers, onSelect }: QuestionListProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      {questions.map((q, idx) => {
+        const currentAnswer = answers[q.id];
+        const hasOptions = Array.isArray(q.options) && q.options.length > 0;
+        const isCustomSelected =
+          hasOptions && currentAnswer !== undefined && !q.options!.includes(currentAnswer);
+
+        return (
+          <div key={q.id} className="border border-gray-200 rounded-2xl p-4 shadow-sm">
+            <div className="flex items-start gap-3 mb-4">
+              <div className="w-7 h-7 flex items-center justify-center bg-purple-100 text-[#7C3AED] rounded-full font-bold text-sm shrink-0">
+                {idx + 1}
+              </div>
+              <h3 className="font-bold text-gray-900 text-base pt-0.5">{q.text}</h3>
+            </div>
+
+            {!hasOptions ? (
+              <textarea
+                placeholder="직접 입력해주세요..."
+                value={currentAnswer || ''}
+                onChange={(e) => onSelect(q.id, e.target.value)}
+                rows={3}
+                className="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white resize-none"
+              />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {q.options!.map((option) => {
+                  const isSelected = currentAnswer === option;
+                  return (
+                    <label
+                      key={option}
+                      className={`flex items-center gap-3 px-4 py-2.5 border-2 rounded-xl cursor-pointer transition-colors ${
+                        isSelected
+                          ? 'border-blue-500 bg-blue-50'
+                          : 'border-transparent bg-gray-50 hover:bg-gray-100'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={q.id}
+                        checked={isSelected}
+                        onChange={() => onSelect(q.id, option)}
+                        className="w-4 h-4 accent-blue-600 cursor-pointer"
+                      />
+                      <span
+                        className={`text-sm ${
+                          isSelected ? 'text-blue-700 font-semibold' : 'text-gray-700 font-medium'
+                        }`}
+                      >
+                        {option}
+                      </span>
+                    </label>
+                  );
+                })}
+
+                <div className="flex flex-col gap-1.5 mt-0.5">
+                  <label
+                    className={`flex items-center gap-3 px-4 py-2.5 border-2 rounded-xl cursor-pointer transition-colors ${
+                      isCustomSelected
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-transparent bg-gray-50 hover:bg-gray-100'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name={q.id}
+                      checked={isCustomSelected}
+                      onChange={() => onSelect(q.id, '')}
+                      className="w-4 h-4 accent-blue-600 cursor-pointer"
+                    />
+                    <span
+                      className={`text-sm ${
+                        isCustomSelected
+                          ? 'text-blue-700 font-semibold'
+                          : 'text-gray-700 font-medium'
+                      }`}
+                    >
+                      ✏️ 직접 입력
+                    </span>
+                  </label>
+
+                  {isCustomSelected && (
+                    <input
+                      type="text"
+                      placeholder="직접 입력해주세요..."
+                      value={currentAnswer || ''}
+                      onChange={(e) => onSelect(q.id, e.target.value)}
+                      className="w-full border border-blue-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+                      autoFocus
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/main/QuestionPanel.tsx
+++ b/src/components/main/QuestionPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Button from '../ui/Button';
+import QuestionList from './QuestionList';
 import { useFeedbackStore } from '@/store/FeedbackStore';
 import useFeedback from '@/hooks/useFeedback';
 import type { Question } from '@/types/document';
@@ -48,104 +49,7 @@ export default function QuestionPanel() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-4">
-        {questions.map((q, idx) => {
-          const currentAnswer = answers[q.id];
-          const hasOptions = Array.isArray(q.options) && q.options.length > 0;
-          const isCustomSelected =
-            hasOptions && currentAnswer !== undefined && !q.options!.includes(currentAnswer);
-
-          return (
-            <div key={q.id} className="border border-gray-200 rounded-2xl p-4 shadow-sm">
-              <div className="flex items-start gap-3 mb-4">
-                <div className="w-7 h-7 flex items-center justify-center bg-purple-100 text-[#7C3AED] rounded-full font-bold text-sm shrink-0">
-                  {idx + 1}
-                </div>
-                <h3 className="font-bold text-gray-900 text-base pt-0.5">{q.text}</h3>
-              </div>
-
-              {!hasOptions ? (
-                <textarea
-                  placeholder="직접 입력해주세요..."
-                  value={currentAnswer || ''}
-                  onChange={(e) => handleSelect(q.id, e.target.value)}
-                  rows={3}
-                  className="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white resize-none"
-                />
-              ) : (
-                <div className="flex flex-col gap-2">
-                  {q.options!.map((option) => {
-                    const isSelected = currentAnswer === option;
-                    return (
-                      <label
-                        key={option}
-                        className={`flex items-center gap-3 px-4 py-2.5 border-2 rounded-xl cursor-pointer transition-colors ${
-                          isSelected
-                            ? 'border-blue-500 bg-blue-50'
-                            : 'border-transparent bg-gray-50 hover:bg-gray-100'
-                        }`}
-                      >
-                        <input
-                          type="radio"
-                          name={q.id}
-                          checked={isSelected}
-                          onChange={() => handleSelect(q.id, option)}
-                          className="w-4 h-4 accent-blue-600 cursor-pointer"
-                        />
-                        <span
-                          className={`text-sm ${
-                            isSelected ? 'text-blue-700 font-semibold' : 'text-gray-700 font-medium'
-                          }`}
-                        >
-                          {option}
-                        </span>
-                      </label>
-                    );
-                  })}
-
-                  <div className="flex flex-col gap-1.5 mt-0.5">
-                    <label
-                      className={`flex items-center gap-3 px-4 py-2.5 border-2 rounded-xl cursor-pointer transition-colors ${
-                        isCustomSelected
-                          ? 'border-blue-500 bg-blue-50'
-                          : 'border-transparent bg-gray-50 hover:bg-gray-100'
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name={q.id}
-                        checked={isCustomSelected}
-                        onChange={() => handleSelect(q.id, '')}
-                        className="w-4 h-4 accent-blue-600 cursor-pointer"
-                      />
-                      <span
-                        className={`text-sm ${
-                          isCustomSelected
-                            ? 'text-blue-700 font-semibold'
-                            : 'text-gray-700 font-medium'
-                        }`}
-                      >
-                        ✏️ 직접 입력
-                      </span>
-                    </label>
-
-                    {isCustomSelected && (
-                      <input
-                        type="text"
-                        placeholder="직접 입력해주세요..."
-                        value={currentAnswer || ''}
-                        onChange={(e) => handleSelect(q.id, e.target.value)}
-                        className="w-full border border-blue-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
-                        autoFocus
-                      />
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      <QuestionList questions={questions} answers={answers} onSelect={handleSelect} />
 
       <div className="mt-4 flex flex-col items-center gap-3 pb-8">
         <Button

--- a/src/hooks/useCollabEditor.ts
+++ b/src/hooks/useCollabEditor.ts
@@ -12,6 +12,7 @@ import { handleSocketError } from '@/shared/socketErrorHandler';
 import type { DocumentServerMessage } from '@/types/socket';
 import { useFeedbackStore } from '@/store/FeedbackStore';
 import { restoreFeedbackState } from '@/hooks/useFeedback';
+import { useTeamspaceStore } from '@/store/teamspaceStore';
 
 function base64ToUint8Array(b64: string): Uint8Array {
   return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
@@ -53,6 +54,7 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
   const applyMarkdownRef = useRef<((md: string) => Promise<void>) | null>(null);
   const pendingDraftRef = useRef<string | null>(null);
   const { setYdoc } = useFeedbackStore();
+  const restoreDraftQA = useTeamspaceStore((state) => state.restoreDraftQA);
 
   useEffect(() => {
     if (doc) {
@@ -99,6 +101,11 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
           } else {
             pendingDraftRef.current = draftContent;
           }
+        }
+        // IDEA 문서 전용 중간 상태 — doc:init.activeDraft에는 questions가 없으므로(알려진 백엔드 갭)
+        // 같은 세션에서 이미 draft:questioning을 수신한 경우가 아니라면 폴백 상태로 복원한다.
+        if (msg.activeDraft?.status === 'QUESTIONING' || msg.activeDraft?.status === 'ANSWERING') {
+          restoreDraftQA(docId, msg.activeDraft.draftId, msg.activeDraft.status);
         }
         return;
       }
@@ -204,7 +211,7 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
       doc.off('update', handleUpdate);
       ws.close(1000);
     };
-  }, [docId, token, doc, provider, editable]);
+  }, [docId, token, doc, provider, editable, restoreDraftQA]);
 
   const editor = useCreateBlockNote({
     collaboration: {

--- a/src/hooks/useCollabEditor.ts
+++ b/src/hooks/useCollabEditor.ts
@@ -102,10 +102,13 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
             pendingDraftRef.current = draftContent;
           }
         }
-        // IDEA 문서 전용 중간 상태 — doc:init.activeDraft에는 questions가 없으므로(알려진 백엔드 갭)
-        // 같은 세션에서 이미 draft:questioning을 수신한 경우가 아니라면 폴백 상태로 복원한다.
         if (msg.activeDraft?.status === 'QUESTIONING' || msg.activeDraft?.status === 'ANSWERING') {
-          restoreDraftQA(docId, msg.activeDraft.draftId, msg.activeDraft.status);
+          restoreDraftQA(
+            docId,
+            msg.activeDraft.draftId,
+            msg.activeDraft.status,
+            msg.activeDraft.questions
+          );
         }
         return;
       }

--- a/src/hooks/useDraft.ts
+++ b/src/hooks/useDraft.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '@/shared/apiClient';
+import type { Answer } from '@/types/document';
+
+interface SubmitDraftAnswersResult {
+  draftId: string;
+  status: 'ANSWERING';
+}
+
+// IDEA 초안 질문에 대한 답변을 제출한다.
+// answer를 빈 배열로 보내면 백엔드가 "건너뛰기"로 해석한다 (피드백 답변과 달리 @NotEmpty 제약이 없음).
+async function submitDraftAnswersRaw(draftId: string, answer: Answer[]) {
+  // questionId/value가 비어있는 항목은 @NotBlank 위반(400)이므로 제외하고 전송한다.
+  // "이 질문은 건너뛴다"는 의도는 항목 자체를 배열에서 제외하는 방식으로 표현한다.
+  const filtered = answer.filter((a) => a.questionId.trim() !== '' && a.value.trim() !== '');
+  const res = await apiClient.post(`/api/drafts/${draftId}/answers`, { answer: filtered });
+  return res.data.data as SubmitDraftAnswersResult;
+}
+
+async function skipDraftQuestionsRaw(draftId: string) {
+  const res = await apiClient.post(`/api/drafts/${draftId}/answers`, { answer: [] });
+  return res.data.data as SubmitDraftAnswersResult;
+}
+
+export default function useDraft() {
+  const submitDraftAnswers = (draftId: string, answer: Answer[]) =>
+    submitDraftAnswersRaw(draftId, answer);
+
+  const skipDraftQuestions = (draftId: string) => skipDraftQuestionsRaw(draftId);
+
+  return {
+    submitDraftAnswers,
+    skipDraftQuestions,
+  };
+}

--- a/src/hooks/useTeamspaceSocket.ts
+++ b/src/hooks/useTeamspaceSocket.ts
@@ -22,6 +22,7 @@ function isTeamspaceServerMessage(message: unknown): message is TeamspaceServerM
   const event = (message as { event?: unknown }).event;
   return (
     event === 'teamspace:init' ||
+    event === 'draft:questioning' ||
     event === 'draft:ready' ||
     event === 'draft:error' ||
     event === 'member:update'
@@ -38,6 +39,8 @@ export function useTeamspaceSocket({
   const setOnlineMembers = useTeamspaceStore((state) => state.setOnlineMembers);
   const setDocumentAiStatus = useTeamspaceStore((state) => state.setDocumentAiStatus);
   const setPendingDraft = useTeamspaceStore((state) => state.setPendingDraft);
+  const setDraftQuestioning = useTeamspaceStore((state) => state.setDraftQuestioning);
+  const clearDraftQA = useTeamspaceStore((state) => state.clearDraftQA);
   const clearTeamspacePresence = useTeamspaceStore((state) => state.clearTeamspacePresence);
 
   useEffect(() => {
@@ -63,14 +66,21 @@ export function useTeamspaceSocket({
         return;
       }
 
+      if (message.event === 'draft:questioning') {
+        setDraftQuestioning(message.data.documentId, message.data.draftId, message.data.questions);
+        return;
+      }
+
       if (message.event === 'draft:ready') {
         setDocumentAiStatus(message.data.documentId, 'IDLE');
         setPendingDraft({ documentId: message.data.documentId, content: message.data.content });
+        clearDraftQA();
         return;
       }
 
       if (message.event === 'draft:error') {
         setDocumentAiStatus(message.data.documentId, 'IDLE');
+        clearDraftQA();
         return;
       }
 
@@ -89,7 +99,16 @@ export function useTeamspaceSocket({
       clearTeamspacePresence();
       wsRef.current = null;
     };
-  }, [clearTeamspacePresence, enabled, setDocumentAiStatus, setOnlineMembers, teamspaceId]);
+  }, [
+    clearDraftQA,
+    clearTeamspacePresence,
+    enabled,
+    setDocumentAiStatus,
+    setDraftQuestioning,
+    setOnlineMembers,
+    setPendingDraft,
+    teamspaceId,
+  ]);
 
   useEffect(() => {
     const ws = wsRef.current;

--- a/src/store/teamspaceStore.ts
+++ b/src/store/teamspaceStore.ts
@@ -1,10 +1,18 @@
 import { create } from 'zustand';
 import type { ActiveMember } from '@/types/teamspaceSocket';
 import type { DocumentAiStatus } from '@/types/api';
+import type { Question } from '@/types/document';
 
 interface PendingDraft {
   documentId: string;
   content: string;
+}
+
+interface DraftQA {
+  documentId: string;
+  draftId: string;
+  status: 'QUESTIONING' | 'ANSWERING';
+  questions: Question[] | null;
 }
 
 interface TeamspaceState {
@@ -12,10 +20,19 @@ interface TeamspaceState {
   onlineMembers: ActiveMember[];
   documentAiStatuses: Record<string, DocumentAiStatus>;
   pendingDraft: PendingDraft | null;
+  draftQA: DraftQA | null;
   setCurrentTeamspaceId: (id: string | null) => void;
   setOnlineMembers: (members: ActiveMember[]) => void;
   setDocumentAiStatus: (documentId: string, aiStatus: DocumentAiStatus) => void;
   setPendingDraft: (draft: PendingDraft | null) => void;
+  setDraftQuestioning: (documentId: string, draftId: string, questions: Question[]) => void;
+  setDraftAnswering: () => void;
+  restoreDraftQA: (
+    documentId: string,
+    draftId: string,
+    status: 'QUESTIONING' | 'ANSWERING'
+  ) => void;
+  clearDraftQA: () => void;
   clearTeamspacePresence: () => void;
 }
 
@@ -24,6 +41,7 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
   onlineMembers: [],
   documentAiStatuses: {},
   pendingDraft: null,
+  draftQA: null,
   setCurrentTeamspaceId: (id) => set({ currentTeamspaceId: id }),
   setOnlineMembers: (members) => set({ onlineMembers: members }),
   setDocumentAiStatus: (documentId, aiStatus) =>
@@ -31,6 +49,21 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
       documentAiStatuses: { ...state.documentAiStatuses, [documentId]: aiStatus },
     })),
   setPendingDraft: (draft) => set({ pendingDraft: draft }),
+  setDraftQuestioning: (documentId, draftId, questions) =>
+    set({ draftQA: { documentId, draftId, status: 'QUESTIONING', questions } }),
+  setDraftAnswering: () =>
+    set((state) =>
+      state.draftQA ? { draftQA: { ...state.draftQA, status: 'ANSWERING', questions: null } } : {}
+    ),
+  // doc:init.activeDraft로 QUESTIONING/ANSWERING을 복원할 때 사용 — questions는 내려오지 않으므로 null.
+  // 이미 같은 문서의 draftQA가 있다면(같은 세션에서 draft:questioning을 수신해 questions를 보유 중) 덮어쓰지 않는다.
+  restoreDraftQA: (documentId, draftId, status) =>
+    set((state) =>
+      state.draftQA?.documentId === documentId
+        ? {}
+        : { draftQA: { documentId, draftId, status, questions: null } }
+    ),
+  clearDraftQA: () => set({ draftQA: null }),
   clearTeamspacePresence: () =>
-    set({ onlineMembers: [], documentAiStatuses: {}, pendingDraft: null }),
+    set({ onlineMembers: [], documentAiStatuses: {}, pendingDraft: null, draftQA: null }),
 }));

--- a/src/store/teamspaceStore.ts
+++ b/src/store/teamspaceStore.ts
@@ -30,7 +30,8 @@ interface TeamspaceState {
   restoreDraftQA: (
     documentId: string,
     draftId: string,
-    status: 'QUESTIONING' | 'ANSWERING'
+    status: 'QUESTIONING' | 'ANSWERING',
+    questions?: Question[] | null
   ) => void;
   clearDraftQA: () => void;
   clearTeamspacePresence: () => void;
@@ -55,13 +56,13 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
     set((state) =>
       state.draftQA ? { draftQA: { ...state.draftQA, status: 'ANSWERING', questions: null } } : {}
     ),
-  // doc:init.activeDraft로 QUESTIONING/ANSWERING을 복원할 때 사용 — questions는 내려오지 않으므로 null.
+  // doc:init.activeDraft로 상태 복원 시 사용.
   // 이미 같은 문서의 draftQA가 있다면(같은 세션에서 draft:questioning을 수신해 questions를 보유 중) 덮어쓰지 않는다.
-  restoreDraftQA: (documentId, draftId, status) =>
+  restoreDraftQA: (documentId, draftId, status, questions = null) =>
     set((state) =>
       state.draftQA?.documentId === documentId
         ? {}
-        : { draftQA: { documentId, draftId, status, questions: null } }
+        : { draftQA: { documentId, draftId, status, questions: questions ?? null } }
     ),
   clearDraftQA: () => set({ draftQA: null }),
   clearTeamspacePresence: () =>

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -42,6 +42,7 @@ export interface ActiveDraftInfo {
   draftId: string;
   status: 'PENDING' | 'QUESTIONING' | 'ANSWERING' | 'DONE' | 'FAILED';
   content?: string | null;
+  questions?: Question[] | null;
 }
 
 export interface DocInitEvent {

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -40,7 +40,7 @@ export interface ActiveFeedbackInfo {
 
 export interface ActiveDraftInfo {
   draftId: string;
-  status: 'PENDING' | 'PROCESSING' | 'DONE' | 'ERROR';
+  status: 'PENDING' | 'QUESTIONING' | 'ANSWERING' | 'DONE' | 'FAILED';
   content?: string | null;
 }
 
@@ -153,6 +153,15 @@ export interface TeamspaceInitEvent {
   };
 }
 
+export interface DraftQuestioningEvent {
+  event: 'draft:questioning';
+  data: {
+    documentId: string;
+    draftId: string;
+    questions: Question[];
+  };
+}
+
 export interface DraftReadyEvent {
   event: 'draft:ready';
   data: {
@@ -182,6 +191,7 @@ export interface TeamspaceSocketErrorEvent {
 
 export type TeamspaceServerMessage =
   | TeamspaceInitEvent
+  | DraftQuestioningEvent
   | DraftReadyEvent
   | DraftErrorEvent
   | MemberUpdateEvent

--- a/src/types/teamspaceSocket.ts
+++ b/src/types/teamspaceSocket.ts
@@ -1,4 +1,4 @@
-import type { DocumentType, TeamRole } from '@/types/document';
+import type { DocumentType, Question, TeamRole } from '@/types/document';
 
 export type MemberRole = TeamRole;
 
@@ -31,6 +31,15 @@ export interface TeamspaceInitEvent {
   };
 }
 
+export interface DraftQuestioningEvent {
+  event: 'draft:questioning';
+  data: {
+    documentId: string;
+    draftId: string;
+    questions: Question[];
+  };
+}
+
 export interface DraftReadyEvent {
   event: 'draft:ready';
   data: {
@@ -56,6 +65,7 @@ export interface MemberUpdateEvent {
 
 export type TeamspaceServerMessage =
   | TeamspaceInitEvent
+  | DraftQuestioningEvent
   | DraftReadyEvent
   | DraftErrorEvent
   | MemberUpdateEvent;


### PR DESCRIPTION
## 📝 작업 내용

AI 초안 생성 전 추가 정보 수집을 위한 Q&A 흐름을 구현하고, 질문 상태에서 레이아웃이 깨지던 문제를 해결했습니다.

주요 변경 사항:
- draft:questioning 소켓 이벤트 수신 및 DraftQA 상태 관리 추가
- DraftQuestionPanel: 에디터 위에 오버레이되는 질문 입력 UI 컴포넌트 구현
- QuestionList: DraftQuestionPanel과 기존 QuestionPanel의 공용 질문 목록 컴포넌트로 추출
- useDraft: 답변 제출 및 건너뛰기 API 훅 추가
- doc:init.activeDraft로 QUESTIONING/ANSWERING 상태 재연결 복원 (새로고침 대응)
- 초안 질문 상태에서 레이아웃이 깨지던 문제 해결
- 질문 상태에서 새로고침 시 기존 질문 내용 복구 처리

<br>

## 테스트 및 검증 내용

- 팀스페이스 생성 후 Q&A 패널이 정상 노출되는지 확인
- 답변 제출 및 건너뛰기 후 초안 생성이 이어지는지 확인
- 질문 진행 중 새로고침 시 질문 상태가 복원되는지 확인
- 질문 패널 오버레이 표시 시 레이아웃이 깨지지 않는지 확인

<br>

## 🤔 주요 고민과 해결 과정

**[새로고침 시 Q&A 상태 복원]**

소켓 이벤트 기반 상태는 페이지 새로고침 시 유실됨.
doc:init 응답의 activeDraft 필드에 QUESTIONING/ANSWERING 상태와 질문 데이터를 포함시켜
재연결 시 즉시 UI를 복원하는 방식으로 해결.
