### PR TITLE
권한 관리 구현

### DIFF
--- a/src/components/main/MemberModal.tsx
+++ b/src/components/main/MemberModal.tsx
@@ -1,9 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { apiClient } from '@/shared/apiClient';
 import { useTeamspaceStore } from '@/store/teamspaceStore';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import UserAvatar from '@/components/ui/UserAvatar';
 import Button from '@/components/ui/Button';
+import MemberRoleSelect from './MemberRoleSelect';
 import type { MemberInfo, PendingInvitation, InviteResponse } from '@/types/api';
+import type { TeamRole } from '@/types/document';
 
 interface MemberModalProps {
   isMemberModalOpen: boolean;
@@ -11,10 +14,24 @@ interface MemberModalProps {
 }
 
 export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: MemberModalProps) {
-  const { currentTeamspaceId } = useTeamspaceStore();
+  const { currentTeamspaceId, onlineMembers } = useTeamspaceStore();
+  const { user } = useCurrentUser();
   const [members, setMembers] = useState<MemberInfo[]>([]);
   const [pendingInvitations, setPendingInvitations] = useState<PendingInvitation[]>([]);
   const [email, setEmail] = useState('');
+  const [updatingMemberId, setUpdatingMemberId] = useState<number | null>(null);
+
+  // 다른 클라이언트의 역할 변경(member:role_changed)을 모달에도 반영
+  const displayMembers = useMemo(
+    () =>
+      members.map((m) => {
+        const online = onlineMembers.find((o) => o.userId === m.userId);
+        return online && online.role !== m.role ? { ...m, role: online.role } : m;
+      }),
+    [members, onlineMembers]
+  );
+
+  const isOwner = displayMembers.find((m) => m.userId === user?.id)?.role === 'OWNER';
 
   const fetchMembers = useCallback(() => {
     if (!currentTeamspaceId) return;
@@ -35,6 +52,23 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
     const { invitationId } = res.data.data as InviteResponse;
     setPendingInvitations((prev) => [...prev, { invitationId, email: email.trim() }]);
     setEmail('');
+  };
+
+  const handleRoleChange = async (member: MemberInfo, role: TeamRole) => {
+    if (!currentTeamspaceId || role === member.role) return;
+    setUpdatingMemberId(member.userId);
+    try {
+      const res = await apiClient.patch(
+        `/api/teamspaces/${currentTeamspaceId}/members/${member.userId}/role`,
+        { role }
+      );
+      const updated = res.data.data as MemberInfo;
+      setMembers((prev) => prev.map((m) => (m.userId === updated.userId ? updated : m)));
+    } catch {
+      // 에러 토스트는 apiClient 인터셉터에서 처리됨
+    } finally {
+      setUpdatingMemberId(null);
+    }
   };
 
   const handleRemoveMember = async (memberId: string) => {
@@ -65,14 +99,14 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
 
         <div className="text-xs text-gray-500">멤버</div>
         <div className="flex flex-col gap-3">
-          {members.map((member) => (
+          {displayMembers.map((member) => (
             <div key={member.userId} className="flex justify-between items-center">
               <div className="flex gap-3 items-center">
                 <UserAvatar name={member.name} imageUrl={member.profileImageUrl} />
                 <div>
                   <div className="font-medium text-sm">
                     {member.name}
-                    {member.role === 'OWNER' && (
+                    {!isOwner && member.role === 'OWNER' && (
                       <span className="ml-1 text-xs text-primary">(방장)</span>
                     )}
                   </div>
@@ -80,16 +114,26 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
                 </div>
               </div>
 
-              {member.role !== 'OWNER' && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="text-red-500"
-                  onClick={() => handleRemoveMember(String(member.userId))}
-                >
-                  추방
-                </Button>
-              )}
+              <div className="flex items-center gap-2">
+                {isOwner ? (
+                  <MemberRoleSelect
+                    value={member.role}
+                    onChange={(role) => handleRoleChange(member, role)}
+                    disabled={updatingMemberId === member.userId}
+                  />
+                ) : null}
+
+                {(isOwner || member.role !== 'OWNER') && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="text-red-500"
+                    onClick={() => handleRemoveMember(String(member.userId))}
+                  >
+                    추방
+                  </Button>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/main/MemberModal.tsx
+++ b/src/components/main/MemberModal.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { FiX } from 'react-icons/fi';
 import { apiClient } from '@/shared/apiClient';
 import { useTeamspaceStore } from '@/store/teamspaceStore';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import UserAvatar from '@/components/ui/UserAvatar';
 import Button from '@/components/ui/Button';
 import MemberRoleSelect from './MemberRoleSelect';
+import { ROLE_LABELS } from '@/constants/teamRole';
 import type { MemberInfo, PendingInvitation, InviteResponse } from '@/types/api';
 import type { TeamRole } from '@/types/document';
 
@@ -31,7 +33,9 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
     [members, onlineMembers]
   );
 
-  const isOwner = displayMembers.find((m) => m.userId === user?.id)?.role === 'OWNER';
+  const currentMember = displayMembers.find((m) => m.userId === user?.id);
+  const isOwner = currentMember?.role === 'OWNER';
+  const isViewer = currentMember?.role === 'VIEWER';
 
   const fetchMembers = useCallback(() => {
     if (!currentTeamspaceId) return;
@@ -90,9 +94,14 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
       <div className="bg-white rounded-2xl shadow-2xl w-125 p-6 flex flex-col gap-4 relative">
         <div className="flex justify-between items-center">
           <span className="text-2xl font-bold">멤버 관리</span>
-          <Button variant="secondary" size="sm" onClick={toggleMemberModal}>
-            닫기
-          </Button>
+          <button
+            type="button"
+            onClick={toggleMemberModal}
+            className="text-ink-muted hover:text-ink transition-colors"
+            aria-label="닫기"
+          >
+            <FiX size={20} />
+          </button>
         </div>
 
         <hr className="h-px border-none" />
@@ -121,9 +130,11 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
                     onChange={(role) => handleRoleChange(member, role)}
                     disabled={updatingMemberId === member.userId}
                   />
-                ) : null}
+                ) : (
+                  <span className="text-sm text-ink-muted">{ROLE_LABELS[member.role]}</span>
+                )}
 
-                {(isOwner || member.role !== 'OWNER') && (
+                {isOwner && member.userId !== user?.id && (
                   <Button
                     variant="secondary"
                     size="sm"
@@ -166,22 +177,24 @@ export default function MemberModal({ isMemberModalOpen, toggleMemberModal }: Me
 
         <hr className="h-px border-none" />
 
-        <div>
-          <div className="text-xs text-gray-500 mb-2">새 멤버 초대</div>
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleInvite()}
-              placeholder="name@company.com"
-              className="flex-1 border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:border-blue-500 placeholder:text-gray-400 transition-all"
-            />
-            <Button variant="primary" size="sm" onClick={handleInvite}>
-              초대 보내기
-            </Button>
+        {!isViewer && (
+          <div>
+            <div className="text-xs text-gray-500 mb-2">새 멤버 초대</div>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleInvite()}
+                placeholder="name@company.com"
+                className="flex-1 border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:border-blue-500 placeholder:text-gray-400 transition-all"
+              />
+              <Button variant="primary" size="sm" onClick={handleInvite}>
+                초대 보내기
+              </Button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/main/MemberRoleSelect.tsx
+++ b/src/components/main/MemberRoleSelect.tsx
@@ -1,17 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
 import type { TeamRole } from '@/types/document';
+import { ROLE_LABELS } from '@/constants/teamRole';
 
 interface MemberRoleSelectProps {
   value: TeamRole;
   onChange: (role: TeamRole) => void;
   disabled?: boolean;
 }
-
-const ROLE_LABELS: Record<TeamRole, string> = {
-  OWNER: '소유자',
-  MEMBER: '멤버',
-  VIEWER: '뷰어',
-};
 
 const ROLE_OPTIONS: TeamRole[] = ['OWNER', 'MEMBER', 'VIEWER'];
 

--- a/src/components/main/MemberRoleSelect.tsx
+++ b/src/components/main/MemberRoleSelect.tsx
@@ -1,0 +1,80 @@
+import { useState, useRef, useEffect } from 'react';
+import type { TeamRole } from '@/types/document';
+
+interface MemberRoleSelectProps {
+  value: TeamRole;
+  onChange: (role: TeamRole) => void;
+  disabled?: boolean;
+}
+
+const ROLE_LABELS: Record<TeamRole, string> = {
+  OWNER: '소유자',
+  MEMBER: '멤버',
+  VIEWER: '뷰어',
+};
+
+const ROLE_OPTIONS: TeamRole[] = ['OWNER', 'MEMBER', 'VIEWER'];
+
+export default function MemberRoleSelect({ value, onChange, disabled }: MemberRoleSelectProps) {
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={popoverRef}>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 rounded border border-border px-2 py-1 text-sm bg-white text-left outline-none hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <span className="text-ink">{ROLE_LABELS[value]}</span>
+        <svg
+          className="ml-auto shrink-0 text-ink-muted"
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+        >
+          <path
+            d="M2 4l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1 w-28 bg-white border border-border rounded-lg shadow-lg z-20 flex flex-col overflow-hidden py-1">
+          {ROLE_OPTIONS.map((role) => (
+            <button
+              key={role}
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                if (role !== value) onChange(role);
+              }}
+              className={`w-full px-3 py-1.5 text-sm text-left hover:bg-surface transition-colors ${
+                role === value ? 'text-primary font-medium' : 'text-ink'
+              }`}
+            >
+              {ROLE_LABELS[role]}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/constants/teamRole.ts
+++ b/src/constants/teamRole.ts
@@ -1,0 +1,7 @@
+import type { TeamRole } from '@/types/document';
+
+export const ROLE_LABELS: Record<TeamRole, string> = {
+  OWNER: '소유자',
+  MEMBER: '멤버',
+  VIEWER: '뷰어',
+};

--- a/src/hooks/useTeamspaceSocket.ts
+++ b/src/hooks/useTeamspaceSocket.ts
@@ -25,7 +25,8 @@ function isTeamspaceServerMessage(message: unknown): message is TeamspaceServerM
     event === 'draft:questioning' ||
     event === 'draft:ready' ||
     event === 'draft:error' ||
-    event === 'member:update'
+    event === 'member:update' ||
+    event === 'member:role_changed'
   );
 }
 
@@ -37,6 +38,7 @@ export function useTeamspaceSocket({
   const wsRef = useRef<WebSocket | null>(null);
   const documentIdRef = useRef<string | null>(documentId);
   const setOnlineMembers = useTeamspaceStore((state) => state.setOnlineMembers);
+  const setMemberRole = useTeamspaceStore((state) => state.setMemberRole);
   const setDocumentAiStatus = useTeamspaceStore((state) => state.setDocumentAiStatus);
   const setPendingDraft = useTeamspaceStore((state) => state.setPendingDraft);
   const setDraftQuestioning = useTeamspaceStore((state) => state.setDraftQuestioning);
@@ -86,6 +88,11 @@ export function useTeamspaceSocket({
 
       if (message.event === 'member:update') {
         setOnlineMembers(message.data.onlineMembers);
+        return;
+      }
+
+      if (message.event === 'member:role_changed') {
+        setMemberRole(message.data.userId, message.data.role);
       }
     };
 
@@ -105,6 +112,7 @@ export function useTeamspaceSocket({
     enabled,
     setDocumentAiStatus,
     setDraftQuestioning,
+    setMemberRole,
     setOnlineMembers,
     setPendingDraft,
     teamspaceId,

--- a/src/shared/apiClient.ts
+++ b/src/shared/apiClient.ts
@@ -12,6 +12,15 @@ const INVITATION_ERROR_MESSAGES: Record<string, string> = {
   INVITATION_NOT_FOUND: '유효하지 않은 초대입니다.',
 };
 
+// PATCH .../members/{memberId}/role 에서 발생 가능한 에러
+const ROLE_CHANGE_ERROR_MESSAGES: Record<string, string> = {
+  INSUFFICIENT_PERMISSION: '권한 변경은 소유자(Owner)만 할 수 있습니다.',
+  NOT_TEAMSPACE_OWNER: '권한 변경은 소유자(Owner)만 할 수 있습니다.',
+  NOT_TEAMSPACE_MEMBER: '대상이 팀스페이스 멤버가 아닙니다.',
+  TEAMSPACE_LAST_OWNER: '팀스페이스에는 최소 1명의 소유자가 있어야 합니다.',
+  INVALID_INPUT: '잘못된 역할 값입니다.',
+};
+
 // PUT .../backlog/config 에서 generateDraft=true 요청 시 발생 가능한 에러
 const BACKLOG_DRAFT_ERROR_MESSAGES: Record<string, string> = {
   BACKLOG_DRAFT_NOT_FIRST_CREATION: '백로그 설정이 이미 존재하여 초안을 생성할 수 없습니다.',
@@ -55,8 +64,11 @@ apiClient.interceptors.response.use(
       // 401은 refresh 흐름이 처리. 그 외 서버/네트워크 에러는 toast로 표시.
       if (error.response?.status !== 401) {
         const data = error.response?.data as { message?: string; code?: string } | undefined;
+        const isRoleChangeRequest = /\/members\/[^/]+\/role$/.test(originalRequest.url ?? '');
         const customMessage = data?.code
-          ? (INVITATION_ERROR_MESSAGES[data.code] ?? BACKLOG_DRAFT_ERROR_MESSAGES[data.code])
+          ? isRoleChangeRequest
+            ? ROLE_CHANGE_ERROR_MESSAGES[data.code]
+            : (INVITATION_ERROR_MESSAGES[data.code] ?? BACKLOG_DRAFT_ERROR_MESSAGES[data.code])
           : undefined;
         const message = customMessage ?? data?.message ?? '서버와 통신 중 오류가 발생했습니다.';
         useToastStore.getState().addToast({ type: 'error', message });

--- a/src/shared/apiClient.ts
+++ b/src/shared/apiClient.ts
@@ -6,7 +6,7 @@ const INVITATION_ERROR_MESSAGES: Record<string, string> = {
   ALREADY_MEMBER: '이미 팀스페이스에 가입된 사용자입니다.',
   ALREADY_INVITED: '이미 초대가 발송된 이메일입니다.',
   INSUFFICIENT_PERMISSION: '초대 권한이 없습니다.',
-  NOT_TEAMSPACE_OWNER: '일괄 초대는 OWNER만 가능합니다.',
+  NOT_TEAMSPACE_OWNER: 'OWNER만 가능한 작업입니다.',
   INVITATION_001: '초대는 최대 8명까지 가능합니다.',
   INVITATION_EXPIRED: '초대 링크가 만료되었습니다. 초대를 다시 요청하세요.',
   INVITATION_NOT_FOUND: '유효하지 않은 초대입니다.',

--- a/src/store/teamspaceStore.ts
+++ b/src/store/teamspaceStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { ActiveMember } from '@/types/teamspaceSocket';
+import type { ActiveMember, MemberRole } from '@/types/teamspaceSocket';
 import type { DocumentAiStatus } from '@/types/api';
 import type { Question } from '@/types/document';
 
@@ -23,6 +23,7 @@ interface TeamspaceState {
   draftQA: DraftQA | null;
   setCurrentTeamspaceId: (id: string | null) => void;
   setOnlineMembers: (members: ActiveMember[]) => void;
+  setMemberRole: (userId: number, role: MemberRole) => void;
   setDocumentAiStatus: (documentId: string, aiStatus: DocumentAiStatus) => void;
   setPendingDraft: (draft: PendingDraft | null) => void;
   setDraftQuestioning: (documentId: string, draftId: string, questions: Question[]) => void;
@@ -45,6 +46,10 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
   draftQA: null,
   setCurrentTeamspaceId: (id) => set({ currentTeamspaceId: id }),
   setOnlineMembers: (members) => set({ onlineMembers: members }),
+  setMemberRole: (userId, role) =>
+    set((state) => ({
+      onlineMembers: state.onlineMembers.map((m) => (m.userId === userId ? { ...m, role } : m)),
+    })),
   setDocumentAiStatus: (documentId, aiStatus) =>
     set((state) => ({
       documentAiStatuses: { ...state.documentAiStatuses, [documentId]: aiStatus },

--- a/src/types/teamspaceSocket.ts
+++ b/src/types/teamspaceSocket.ts
@@ -63,12 +63,21 @@ export interface MemberUpdateEvent {
   };
 }
 
+export interface MemberRoleChangedEvent {
+  event: 'member:role_changed';
+  data: {
+    userId: number;
+    role: MemberRole;
+  };
+}
+
 export type TeamspaceServerMessage =
   | TeamspaceInitEvent
   | DraftQuestioningEvent
   | DraftReadyEvent
   | DraftErrorEvent
-  | MemberUpdateEvent;
+  | MemberUpdateEvent
+  | MemberRoleChangedEvent;
 
 export interface MemberFocusRequest {
   event: 'member:focus';


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #77

<br>

## 📝 작업 내용

팀스페이스 내 멤버 권한(Owner / Editor / Viewer) 관리 기능을 구현했습니다.
Owner는 멤버 권한을 드롭다운으로 변경할 수 있고, 권한에 따라 멤버 관리 모달의 UI 노출 범위가 달라집니다.

주요 변경 사항:
- Owner가 멤버 역할을 드롭다운으로 변경, 실패 시 에러 토스트로 안내
- Owner가 아닌 멤버에게는 역할을 텍스트로만 표시 (변경 불가)
- 멤버 추방 버튼은 Owner에게만 노출
- Viewer에게는 새 멤버 초대 폼 숨김
- 모달 닫기 버튼을 X 아이콘으로 교체
- ROLE_LABELS 상수를 constants/teamRole로 분리해 재사용성 확보

<br>

## 🖼️ 스크린샷 (선택)

<img width="1917" height="865" alt="image" src="https://github.com/user-attachments/assets/4d80d324-976c-434f-b8bc-4cbc43047303" />

<br>

## 테스트 및 검증 내용

- Owner 계정에서 다른 멤버의 역할 드롭다운이 표시되고, 변경이 정상 적용되는지 확인
- Editor/Viewer 계정에서 역할이 텍스트로만 노출되는지 확인
- Viewer 계정에서 초대 폼이 숨겨지는지 확인
- 역할 변경 실패 시 에러 토스트가 노출되는지 확인

<br>

## 🤔 주요 고민과 해결 과정

**[권한별 UI 분기 일관성 유지]**

멤버 관리 모달 내 여러 UI 요소(드롭다운, 추방 버튼, 초대 폼)가 각각 권한 조건을 중복해서 체크하면
유지보수 시 누락이 발생할 수 있음. ROLE_LABELS와 권한 체크 로직을 constants/teamRole로 분리해
단일 출처(single source of truth)로 관리.
