### PR TITLE
Hotfix: 키보드 커서 위치에 유저명이 익명이라고 뜨는 부분 해결

### DIFF
--- a/src/components/backlog/BacklogListView.tsx
+++ b/src/components/backlog/BacklogListView.tsx
@@ -111,39 +111,39 @@ export default function BacklogListView({
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      {/* Table column header */}
-      <div className="flex items-center border-b border-border bg-surface shrink-0 text-xs font-semibold text-ink-muted select-none">
-        <div className="flex-1 px-4 py-2">제목</div>
-        <div className={`${COL_WIDTHS.assignees} px-3 py-2 border-l border-border text-center`}>
-          담당자
-        </div>
-        <div className={`${COL_WIDTHS.status} px-3 py-2 border-l border-border text-center`}>
-          상태
-        </div>
-        {config.feBeEnabled && (
-          <div className={`${COL_WIDTHS.issueType} px-3 py-2 border-l border-border text-center`}>
-            이슈 타입
-          </div>
-        )}
-        {config.priorityEnabled && (
-          <div className={`${COL_WIDTHS.priority} px-3 py-2 border-l border-border text-center`}>
-            중요도
-          </div>
-        )}
-        {config.sprintEnabled && (
-          <div className={`${COL_WIDTHS.sprint} px-3 py-2 border-l border-border text-center`}>
-            스프린트
-          </div>
-        )}
-        {config.dueDateEnabled && (
-          <div className={`${COL_WIDTHS.dueDate} px-3 py-2 border-l border-border text-center`}>
-            마감일
-          </div>
-        )}
-        <div className="w-8" />
-      </div>
-
       <div className="flex-1 overflow-y-auto">
+        {/* Table column header */}
+        <div className="flex items-center border-b border-border bg-surface sticky top-0 z-10 text-xs font-semibold text-ink-muted select-none">
+          <div className="flex-1 px-4 py-2">제목</div>
+          <div className={`${COL_WIDTHS.assignees} px-3 py-2 border-l border-border text-center`}>
+            담당자
+          </div>
+          <div className={`${COL_WIDTHS.status} px-3 py-2 border-l border-border text-center`}>
+            상태
+          </div>
+          {config.feBeEnabled && (
+            <div className={`${COL_WIDTHS.issueType} px-3 py-2 border-l border-border text-center`}>
+              이슈 타입
+            </div>
+          )}
+          {config.priorityEnabled && (
+            <div className={`${COL_WIDTHS.priority} px-3 py-2 border-l border-border text-center`}>
+              중요도
+            </div>
+          )}
+          {config.sprintEnabled && (
+            <div className={`${COL_WIDTHS.sprint} px-3 py-2 border-l border-border text-center`}>
+              스프린트
+            </div>
+          )}
+          {config.dueDateEnabled && (
+            <div className={`${COL_WIDTHS.dueDate} px-3 py-2 border-l border-border text-center`}>
+              마감일
+            </div>
+          )}
+          <div className="w-8" />
+        </div>
+
         {isEmpty ? (
           <div className="flex items-center justify-center h-32 text-sm text-ink-muted">
             이슈가 없습니다.

--- a/src/components/backlog/BacklogTaskFormModal.tsx
+++ b/src/components/backlog/BacklogTaskFormModal.tsx
@@ -10,6 +10,8 @@ import type {
   StorySummary,
 } from '@/types/backlog';
 import type { MemberInfo } from '@/types/api';
+import { STATUS_OPTIONS, PRIORITY_OPTIONS, ISSUE_TYPE_OPTIONS } from '@/constants/backlog';
+import AssigneeSelect from './AssigneeSelect';
 interface BacklogTaskFormModalProps {
   mode: 'create' | 'edit';
   initialData?: Partial<CreateBacklogTaskRequest> & { id?: number };
@@ -26,6 +28,8 @@ export default function BacklogTaskFormModal({
   initialData,
   defaultStatus,
   config,
+  members,
+  stories,
   onSave,
   onClose,
 }: BacklogTaskFormModalProps) {
@@ -113,6 +117,116 @@ export default function BacklogTaskFormModal({
             />
             {titleError && <p className="text-xs text-red-500">제목을 입력해주세요.</p>}
           </div>
+
+          {/* 상태 */}
+          <FormRow label="상태">
+            <select
+              value={form.status}
+              onChange={(e) => set('status', e.target.value as StoryStatus)}
+              className="rounded border border-border px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary bg-white"
+            >
+              {STATUS_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </FormRow>
+
+          {/* 이슈 유형 (feBeEnabled) */}
+          {config.feBeEnabled && (
+            <FormRow label="이슈 유형">
+              <div className="flex items-center gap-2">
+                {ISSUE_TYPE_OPTIONS.map((o) => (
+                  <button
+                    key={o.value}
+                    type="button"
+                    onClick={() => set('issueType', form.issueType === o.value ? null : o.value)}
+                    className={`px-3 py-1 rounded border text-xs font-medium transition-colors ${
+                      form.issueType === o.value
+                        ? o.value === 'FE'
+                          ? 'bg-blue-50 border-blue-300 text-blue-600'
+                          : 'bg-purple-50 border-purple-300 text-purple-600'
+                        : 'border-border text-ink-muted hover:text-ink'
+                    }`}
+                  >
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+            </FormRow>
+          )}
+
+          {/* 우선순위 (priorityEnabled) */}
+          {config.priorityEnabled && (
+            <FormRow label="우선순위">
+              <select
+                value={form.priority ?? ''}
+                onChange={(e) =>
+                  set('priority', e.target.value ? (e.target.value as Priority) : null)
+                }
+                className="rounded border border-border px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary bg-white"
+              >
+                <option value="">선택 안 함</option>
+                {PRIORITY_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </FormRow>
+          )}
+
+          {/* 상위 스토리 */}
+          {stories.length > 0 && (
+            <FormRow label="상위 스토리">
+              <select
+                value={form.storyId ?? ''}
+                onChange={(e) => set('storyId', e.target.value ? Number(e.target.value) : null)}
+                className="rounded border border-border px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary bg-white max-w-[240px] truncate"
+              >
+                <option value="">없음</option>
+                {stories.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    #{s.number} {s.title}
+                  </option>
+                ))}
+              </select>
+            </FormRow>
+          )}
+
+          {/* 담당자 */}
+          <FormRow label="담당자">
+            <AssigneeSelect
+              value={form.assigneeId}
+              members={members}
+              onChange={(id) => set('assigneeId', id)}
+            />
+          </FormRow>
+
+          {/* 스프린트 (sprintEnabled) */}
+          {config.sprintEnabled && (
+            <FormRow label="스프린트">
+              <input
+                value={form.sprint}
+                onChange={(e) => set('sprint', e.target.value)}
+                placeholder="Sprint 1"
+                className="rounded border border-border px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary w-40"
+              />
+            </FormRow>
+          )}
+
+          {/* 마감일 (dueDateEnabled) */}
+          {config.dueDateEnabled && (
+            <FormRow label="마감일">
+              <input
+                type="date"
+                value={form.dueDate}
+                onChange={(e) => set('dueDate', e.target.value)}
+                className="rounded border border-border px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary"
+              />
+            </FormRow>
+          )}
         </div>
 
         {/* 버튼 */}
@@ -132,6 +246,15 @@ export default function BacklogTaskFormModal({
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function FormRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs font-semibold text-ink-muted w-20 shrink-0">{label}</span>
+      <div className="flex items-center gap-2">{children}</div>
     </div>
   );
 }

--- a/src/components/document/CollaborativeEditor.tsx
+++ b/src/components/document/CollaborativeEditor.tsx
@@ -1,18 +1,41 @@
 import '@blocknote/mantine/style.css';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCollabEditor } from '@/hooks/useCollabEditor';
 import { useDocumentEditorStore } from '@/store/documentEditorStore';
 import { useTeamspaceStore } from '@/store/teamspaceStore';
+import { useToastStore } from '@/store/toastStore';
 import DraftQuestionPanel from '@/components/main/DraftQuestionPanel';
 
 interface Props {
   docId: string;
   editable: boolean;
   isAiDraftGenerating?: boolean;
+  isViewer?: boolean;
   user: { name: string; color: string };
   token: string;
 }
+
+// 키보드 입력 중 편집을 시도하는 키만 토스트 대상으로 간주 (방향키, 복사 등은 제외)
+const NON_EDITING_KEYS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+  'Tab',
+  'Shift',
+  'Control',
+  'Alt',
+  'Meta',
+  'Escape',
+  'CapsLock',
+]);
+
+const VIEWER_EDIT_TOAST_INTERVAL_MS = 3000;
 
 function LoadingSpinner({ message }: { message: string }) {
   return (
@@ -42,10 +65,18 @@ function LoadingSpinner({ message }: { message: string }) {
   );
 }
 
-function CollaborativeEditor({ docId, editable, isAiDraftGenerating = false, user, token }: Props) {
+function CollaborativeEditor({
+  docId,
+  editable,
+  isAiDraftGenerating = false,
+  isViewer = false,
+  user,
+  token,
+}: Props) {
   const { editor } = useCollabEditor({ docId, editable, user, token });
   const setEditor = useDocumentEditorStore((state) => state.setEditor);
   const draftQA = useTeamspaceStore((state) => state.draftQA);
+  const lastViewerToastRef = useRef(0);
 
   useEffect(() => {
     setEditor(editor);
@@ -53,14 +84,37 @@ function CollaborativeEditor({ docId, editable, isAiDraftGenerating = false, use
     return () => setEditor(null);
   }, [editor, setEditor]);
 
+  const notifyViewerEditAttempt = () => {
+    const now = Date.now();
+    if (now - lastViewerToastRef.current < VIEWER_EDIT_TOAST_INTERVAL_MS) return;
+    lastViewerToastRef.current = now;
+    useToastStore.getState().addToast({
+      type: 'error',
+      message: '권한이 없어 편집할 수 없습니다.',
+    });
+  };
+
+  const handleViewerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.ctrlKey || e.metaKey || NON_EDITING_KEYS.has(e.key)) return;
+    notifyViewerEditAttempt();
+  };
+
+  const handleViewerPaste = () => {
+    notifyViewerEditAttempt();
+  };
+
   // IDEA 초안 Q&A 흐름의 세부 단계 — 같은 문서에 대한 draftQA가 있을 때만 의미가 있다.
   const isQuestioningThisDoc = draftQA?.documentId === docId && draftQA.status === 'QUESTIONING';
   const isAnsweringThisDoc = draftQA?.documentId === docId && draftQA.status === 'ANSWERING';
 
   return (
     <div className="relative min-h-[calc(100vh-160px)]">
-      <div inert={isAiDraftGenerating || undefined}>
-        <BlockNoteView editor={editor} theme="light" />
+      <div
+        inert={isAiDraftGenerating || undefined}
+        onKeyDownCapture={isViewer ? handleViewerKeyDown : undefined}
+        onPasteCapture={isViewer ? handleViewerPaste : undefined}
+      >
+        <BlockNoteView editor={editor} theme="light" editable={editable} />
       </div>
       {isQuestioningThisDoc && <DraftQuestionPanel documentId={docId} />}
       {!isQuestioningThisDoc && isAnsweringThisDoc && (

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -26,9 +26,10 @@ export default function MainContent() {
   const isSplitView = useFeedbackStore((state) => state.isSplitView);
   const status = useFeedbackStore((state) => state.status);
   const feedbackId = useFeedbackStore((state) => state.feedbackId);
-  const { currentTeamspaceId, documentAiStatuses } = useTeamspaceStore();
+  const { currentTeamspaceId, documentAiStatuses, onlineMembers } = useTeamspaceStore();
   const { teamspace } = useTeamspaceDetail(currentTeamspaceId);
   const isAiDraftGenerating = docId ? documentAiStatuses[docId] === 'DRAFT' : false;
+  const isViewer = onlineMembers.find((m) => m.userId === user?.id)?.role === 'VIEWER';
 
   const resetFeedback = useFeedbackStore((state) => state.resetFeedback);
   const { startPolling, stopPolling } = useFeedback();
@@ -98,8 +99,9 @@ export default function MainContent() {
           <CollaborativeEditor
             key={docId}
             docId={docId}
-            editable={!isAiDraftGenerating}
+            editable={!isAiDraftGenerating && !isViewer}
             isAiDraftGenerating={isAiDraftGenerating}
+            isViewer={isViewer}
             user={collabUser}
             token=""
           />

--- a/src/hooks/useCollabEditor.ts
+++ b/src/hooks/useCollabEditor.ts
@@ -8,6 +8,7 @@ import {
 } from 'y-protocols/awareness';
 import { useCreateBlockNote } from '@blocknote/react';
 import { ko } from '@blocknote/core/locales';
+import { YCursorExtension } from '@blocknote/core';
 import { handleSocketError } from '@/shared/socketErrorHandler';
 import type { DocumentServerMessage } from '@/types/socket';
 import { useFeedbackStore } from '@/store/FeedbackStore';
@@ -226,6 +227,12 @@ export function useCollabEditor({ docId, user, token, editable }: UseCollabEdito
     dictionary: ko,
     editable,
   });
+
+  // user 정보는 비동기로 로드되므로, 최초 editor 생성 시점엔 '익명'일 수 있다.
+  // 이후 user가 갱신되면 awareness의 cursor 표시 이름/색상도 함께 갱신한다.
+  useEffect(() => {
+    editor.getExtension(YCursorExtension)?.updateUser({ name: user.name, color: user.color });
+  }, [editor, user.name, user.color]);
 
   useEffect(() => {
     applyMarkdownRef.current = (md: string) => {

--- a/src/shared/apiClient.ts
+++ b/src/shared/apiClient.ts
@@ -5,7 +5,7 @@ import { useToastStore } from '@/store/toastStore';
 const INVITATION_ERROR_MESSAGES: Record<string, string> = {
   ALREADY_MEMBER: '이미 팀스페이스에 가입된 사용자입니다.',
   ALREADY_INVITED: '이미 초대가 발송된 이메일입니다.',
-  INSUFFICIENT_PERMISSION: '초대 권한이 없습니다.',
+  INSUFFICIENT_PERMISSION: '작업을 수행할 수 있는 권한이 없습니다.',
   NOT_TEAMSPACE_OWNER: 'OWNER만 가능한 작업입니다.',
   INVITATION_001: '초대는 최대 8명까지 가능합니다.',
   INVITATION_EXPIRED: '초대 링크가 만료되었습니다. 초대를 다시 요청하세요.',
@@ -15,8 +15,8 @@ const INVITATION_ERROR_MESSAGES: Record<string, string> = {
 // PATCH .../members/{memberId}/role 에서 발생 가능한 에러
 const ROLE_CHANGE_ERROR_MESSAGES: Record<string, string> = {
   INSUFFICIENT_PERMISSION: '권한 변경은 소유자(Owner)만 할 수 있습니다.',
-  NOT_TEAMSPACE_OWNER: '권한 변경은 소유자(Owner)만 할 수 있습니다.',
-  NOT_TEAMSPACE_MEMBER: '대상이 팀스페이스 멤버가 아닙니다.',
+  NOT_TEAMSPACE_OWNER: 'OWNER만 가능한 작업입니다.',
+  NOT_TEAMSPACE_MEMBER: '팀스페이스 멤버가 아닙니다.',
   TEAMSPACE_LAST_OWNER: '팀스페이스에는 최소 1명의 소유자가 있어야 합니다.',
   INVALID_INPUT: '잘못된 역할 값입니다.',
 };


### PR DESCRIPTION
## 📝 작업 내용

협업 에디터 커서 프레즌스에 사용자 이름이 '익명'으로 고정되던 버그와 그 외 발견된 버그들을 수정했습니다.

주요 변경 사항:
- 협업 에디터 커서에 사용자 이름이 익명으로 표시되는 문제 수정
  - useCreateBlockNote는 마운트 시 1회만 user 정보를 awareness에 반영하는데, useCurrentUser의 비동기 응답이 늦게 도착하면 초기값 '익명'이 고정되는 문제
  - user 정보가 갱신될 때 YCursorExtension.updateUser로 awareness를 재갱신하도록 처리
- Viewer 권한 멤버는 BlockNote 레벨에서 편집 불가 처리
- 태스크 이슈 생성 시 제목만 표시되던 문제 해결 (옵션 항목 누락 수정)
- 백로그 모달에서 스크롤 발생 시 레이아웃이 밀리던 문제 해결
- 에러 문구 수정

<br>

## 테스트 및 검증 내용

- 에디터 진입 시 커서 레이블에 실제 로그인 사용자 이름이 표시되는지 확인
- 네트워크 속도가 느린 환경에서도 user 정보 로드 후 이름이 올바르게 갱신되는지 확인
- Viewer 계정에서 BlockNote 편집이 비활성화되는지 확인
- 태스크 이슈 생성 모달에서 모든 옵션이 표시되는지 확인

<br>

## 🤔 주요 고민과 해결 과정

**[awareness 초기화 타이밍 문제]**

useCreateBlockNote가 에디터 인스턴스를 생성할 때 useCurrentUser 데이터가 아직 undefined 상태라
awareness에 '익명'이 기록되고 이후 업데이트가 되지 않음. BlockNote의 YCursorExtension에
updateUser API가 있음을 확인하고, useCurrentUser가 실제 유저 데이터를 받아오는 시점에
해당 API를 호출해 awareness를 갱신하는 방식으로 해결.
