### PR TITLE
문서 종류에 자유 문서 추가

### DIFF
--- a/src/components/CreateTeamSpace/Step1.tsx
+++ b/src/components/CreateTeamSpace/Step1.tsx
@@ -51,7 +51,7 @@ export default function Step1({ form, onChange, onNext }: Props) {
         <div>
           <p className="text-xs text-gray-500 mb-2">필요한 기획 문서 선택</p>
           <div className="grid grid-cols-2 gap-2">
-            {DOC_OPTIONS.map((doc) => {
+            {DOC_OPTIONS.filter((doc) => doc.value !== 'FREE').map((doc) => {
               const isSelected = form.selectedDocs.includes(doc.value);
               const isRequired = doc.value === 'IDEA';
               return (

--- a/src/components/CreateTeamSpace/index.tsx
+++ b/src/components/CreateTeamSpace/index.tsx
@@ -8,7 +8,7 @@ import { apiClient } from '@/shared/apiClient';
 const initialForm: TeamSpaceForm = {
   teamName: '',
   idea: '',
-  selectedDocs: DOC_OPTIONS.map((doc) => doc.value),
+  selectedDocs: DOC_OPTIONS.filter((doc) => doc.value !== 'FREE').map((doc) => doc.value),
   emails: [
     { id: crypto.randomUUID(), value: '', error: null },
     { id: crypto.randomUUID(), value: '', error: null },

--- a/src/components/CreateTeamSpace/types.ts
+++ b/src/components/CreateTeamSpace/types.ts
@@ -1,10 +1,10 @@
 export const DOC_OPTIONS = [
+  { label: '자유 문서', value: 'FREE' },
   { label: '아이디어', value: 'IDEA' },
   { label: '기획서', value: 'PLAN' },
   { label: '유저 시나리오', value: 'USER_SCENARIO' },
   { label: 'API 명세서', value: 'API_SPEC' },
   { label: 'ERD', value: 'ERD' },
-  { label: '자유 문서', value: 'FREE' },
 ] as const;
 
 export type DocType = (typeof DOC_OPTIONS)[number]['value'];

--- a/src/components/CreateTeamSpace/types.ts
+++ b/src/components/CreateTeamSpace/types.ts
@@ -4,6 +4,7 @@ export const DOC_OPTIONS = [
   { label: '유저 시나리오', value: 'USER_SCENARIO' },
   { label: 'API 명세서', value: 'API_SPEC' },
   { label: 'ERD', value: 'ERD' },
+  { label: '자유 문서', value: 'FREE' },
 ] as const;
 
 export type DocType = (typeof DOC_OPTIONS)[number]['value'];

--- a/src/components/main/CreateDocumentModal.tsx
+++ b/src/components/main/CreateDocumentModal.tsx
@@ -1,31 +1,42 @@
 import { useState } from 'react';
 import Button from '@/components/ui/Button';
 import { DOC_OPTIONS, type DocType } from '@/components/CreateTeamSpace/types';
+import type { DocumentType } from '@/types/document';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: (type: DocType) => Promise<void>;
+  onConfirm: (type: DocType, title?: string) => Promise<void>;
+  existingDocTypes: DocumentType[];
 }
 
-export default function CreateDocumentModal({ isOpen, onClose, onConfirm }: Props) {
+const FIXED_TYPES: DocumentType[] = ['IDEA', 'PLAN', 'USER_SCENARIO', 'API_SPEC', 'ERD'];
+
+export default function CreateDocumentModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  existingDocTypes,
+}: Props) {
   const [selectedType, setSelectedType] = useState<DocType | null>(null);
-  const [prompt, setPrompt] = useState('');
+  const [freeTitle, setFreeTitle] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   if (!isOpen) return null;
 
-  const selectedOption = DOC_OPTIONS.find((o) => o.value === selectedType);
-
   const handleTypeSelect = (type: DocType) => {
+    const isDisabled =
+      FIXED_TYPES.includes(type as DocumentType) && existingDocTypes.includes(type as DocumentType);
+    if (isDisabled) return;
     setSelectedType((prev) => (prev === type ? null : type));
   };
 
   const handleConfirm = async () => {
     if (!selectedType) return;
+    if (selectedType === 'FREE' && !freeTitle.trim()) return;
     setIsLoading(true);
     try {
-      await onConfirm(selectedType);
+      await onConfirm(selectedType, selectedType === 'FREE' ? freeTitle.trim() : undefined);
       handleClose();
     } finally {
       setIsLoading(false);
@@ -34,9 +45,12 @@ export default function CreateDocumentModal({ isOpen, onClose, onConfirm }: Prop
 
   const handleClose = () => {
     setSelectedType(null);
-    setPrompt('');
+    setFreeTitle('');
     onClose();
   };
+
+  const isConfirmDisabled =
+    !selectedType || isLoading || (selectedType === 'FREE' && !freeTitle.trim());
 
   return (
     <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
@@ -57,21 +71,32 @@ export default function CreateDocumentModal({ isOpen, onClose, onConfirm }: Prop
           </p>
           <div className="grid grid-cols-3 gap-2">
             {DOC_OPTIONS.map((doc) => {
+              const isFixed = FIXED_TYPES.includes(doc.value as DocumentType);
+              const alreadyExists = isFixed && existingDocTypes.includes(doc.value as DocumentType);
               const isSelected = selectedType === doc.value;
+
               return (
                 <button
                   key={doc.value}
                   type="button"
                   onClick={() => handleTypeSelect(doc.value)}
+                  disabled={alreadyExists}
                   className={
                     'flex justify-between items-center px-3 py-2 text-sm rounded-lg border transition-colors ' +
-                    (isSelected
-                      ? 'border-green-300 bg-green-50 text-gray-700'
-                      : 'border-gray-200 bg-white text-gray-700 hover:border-blue-200 hover:bg-blue-50')
+                    (alreadyExists
+                      ? 'border-gray-100 bg-gray-50 text-gray-300 cursor-not-allowed'
+                      : isSelected
+                        ? 'border-green-300 bg-green-50 text-gray-700'
+                        : 'border-gray-200 bg-white text-gray-700 hover:border-blue-200 hover:bg-blue-50')
                   }
                 >
                   <span>{doc.label}</span>
-                  {isSelected && <span className="text-green-500 text-sm leading-none">✓</span>}
+                  {alreadyExists && (
+                    <span className="text-gray-300 text-xs leading-none">완료</span>
+                  )}
+                  {!alreadyExists && isSelected && (
+                    <span className="text-green-500 text-sm leading-none">✓</span>
+                  )}
                 </button>
               );
             })}
@@ -80,47 +105,57 @@ export default function CreateDocumentModal({ isOpen, onClose, onConfirm }: Prop
 
         {/* 문서 제목 */}
         <div>
-          <p className="text-sm font-medium text-gray-700 mb-2">문서 제목</p>
-          <div
-            className={
-              'w-full px-4 py-2.5 text-sm border rounded-lg select-none ' +
-              (selectedOption
-                ? 'border-gray-200 bg-gray-50 text-gray-500'
-                : 'border-gray-200 bg-gray-50 text-gray-300')
-            }
-          >
-            {selectedOption ? selectedOption.label : '문서 타입을 선택하면 자동으로 설정됩니다'}
-          </div>
+          <p className="text-sm font-medium text-gray-700 mb-2">
+            문서 제목
+            {selectedType === 'FREE' && <span className="ml-1 text-red-400">*</span>}
+          </p>
+          {selectedType === 'FREE' ? (
+            <input
+              type="text"
+              value={freeTitle}
+              onChange={(e) => setFreeTitle(e.target.value)}
+              placeholder="문서 제목을 입력하세요"
+              className="w-full px-4 py-2.5 text-sm border border-gray-300 rounded-lg outline-none focus:border-blue-400 transition-colors text-gray-900 placeholder-gray-400"
+            />
+          ) : (
+            <div
+              className={
+                'w-full px-4 py-2.5 text-sm border rounded-lg select-none ' +
+                (selectedType
+                  ? 'border-gray-200 bg-gray-50 text-gray-500'
+                  : 'border-gray-200 bg-gray-50 text-gray-300')
+              }
+            >
+              {selectedType
+                ? DOC_OPTIONS.find((o) => o.value === selectedType)?.label
+                : '문서 타입을 선택하면 자동으로 설정됩니다'}
+            </div>
+          )}
         </div>
 
-        {/* AI 초안 생성 프롬프트 (UI 껍데기) */}
-        <div>
-          <div className="flex items-center gap-2 mb-2">
-            <p className="text-sm font-medium text-gray-700">AI 초안 생성</p>
-            <span className="bg-gray-100 text-gray-500 text-xs px-2 py-0.5 rounded-md">
-              준비 중
-            </span>
+        {/* AI 초안 생성 — FREE 타입은 미지원이므로 렌더링하지 않음 */}
+        {selectedType !== 'FREE' && (
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <p className="text-sm font-medium text-gray-700">AI 초안 생성</p>
+              <span className="bg-gray-100 text-gray-500 text-xs px-2 py-0.5 rounded-md">
+                준비 중
+              </span>
+            </div>
+            <textarea
+              placeholder="문서 초안을 어떻게 작성할지 AI에게 알려주세요... (준비 중인 기능입니다)"
+              disabled
+              className="w-full h-24 px-4 py-2.5 text-sm border border-gray-200 rounded-lg resize-none text-gray-400 placeholder-gray-300 bg-gray-50 cursor-not-allowed outline-none"
+            />
           </div>
-          <textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="문서 초안을 어떻게 작성할지 AI에게 알려주세요... (준비 중인 기능입니다)"
-            disabled
-            className="w-full h-24 px-4 py-2.5 text-sm border border-gray-200 rounded-lg resize-none text-gray-400 placeholder-gray-300 bg-gray-50 cursor-not-allowed outline-none"
-          />
-        </div>
+        )}
 
         {/* 버튼 */}
         <div className="flex justify-end gap-2">
           <Button variant="secondary" size="sm" onClick={handleClose} disabled={isLoading}>
             취소
           </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={handleConfirm}
-            disabled={!selectedType || isLoading}
-          >
+          <Button variant="primary" size="sm" onClick={handleConfirm} disabled={isConfirmDisabled}>
             {isLoading ? '생성 중...' : '문서 생성'}
           </Button>
         </div>

--- a/src/components/main/CreateDocumentModal.tsx
+++ b/src/components/main/CreateDocumentModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { MdClose } from 'react-icons/md';
 import Button from '@/components/ui/Button';
 import { DOC_OPTIONS, type DocType } from '@/components/CreateTeamSpace/types';
 import type { DocumentType } from '@/types/document';
@@ -18,7 +19,7 @@ export default function CreateDocumentModal({
   onConfirm,
   existingDocTypes,
 }: Props) {
-  const [selectedType, setSelectedType] = useState<DocType | null>(null);
+  const [selectedType, setSelectedType] = useState<DocType | null>('FREE');
   const [freeTitle, setFreeTitle] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -44,7 +45,7 @@ export default function CreateDocumentModal({
   };
 
   const handleClose = () => {
-    setSelectedType(null);
+    setSelectedType('FREE');
     setFreeTitle('');
     onClose();
   };
@@ -58,9 +59,43 @@ export default function CreateDocumentModal({
         {/* 헤더 */}
         <div className="flex justify-between items-center">
           <span className="text-xl font-bold text-gray-900">새 문서 추가</span>
-          <Button variant="secondary" size="sm" onClick={handleClose}>
-            ✕
-          </Button>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <MdClose size={20} />
+          </button>
+        </div>
+
+        {/* 문서 제목 */}
+        <div>
+          <p className="text-sm font-medium text-gray-700 mb-2">
+            문서 제목
+            {selectedType === 'FREE' && <span className="ml-1 text-red-400">*</span>}
+          </p>
+          {selectedType === 'FREE' ? (
+            <input
+              type="text"
+              value={freeTitle}
+              onChange={(e) => setFreeTitle(e.target.value)}
+              placeholder="문서 제목을 입력하세요"
+              className="w-full px-4 py-2.5 text-sm border border-gray-300 rounded-lg outline-none focus:border-blue-400 transition-colors text-gray-900 placeholder-gray-400"
+            />
+          ) : (
+            <div
+              className={
+                'w-full px-4 py-2.5 text-sm border rounded-lg select-none ' +
+                (selectedType
+                  ? 'border-gray-200 bg-gray-50 text-gray-500'
+                  : 'border-gray-200 bg-gray-50 text-gray-300')
+              }
+            >
+              {selectedType
+                ? DOC_OPTIONS.find((o) => o.value === selectedType)?.label
+                : '문서 타입을 선택하면 자동으로 설정됩니다'}
+            </div>
+          )}
         </div>
 
         {/* 문서 타입 선택 */}
@@ -102,53 +137,6 @@ export default function CreateDocumentModal({
             })}
           </div>
         </div>
-
-        {/* 문서 제목 */}
-        <div>
-          <p className="text-sm font-medium text-gray-700 mb-2">
-            문서 제목
-            {selectedType === 'FREE' && <span className="ml-1 text-red-400">*</span>}
-          </p>
-          {selectedType === 'FREE' ? (
-            <input
-              type="text"
-              value={freeTitle}
-              onChange={(e) => setFreeTitle(e.target.value)}
-              placeholder="문서 제목을 입력하세요"
-              className="w-full px-4 py-2.5 text-sm border border-gray-300 rounded-lg outline-none focus:border-blue-400 transition-colors text-gray-900 placeholder-gray-400"
-            />
-          ) : (
-            <div
-              className={
-                'w-full px-4 py-2.5 text-sm border rounded-lg select-none ' +
-                (selectedType
-                  ? 'border-gray-200 bg-gray-50 text-gray-500'
-                  : 'border-gray-200 bg-gray-50 text-gray-300')
-              }
-            >
-              {selectedType
-                ? DOC_OPTIONS.find((o) => o.value === selectedType)?.label
-                : '문서 타입을 선택하면 자동으로 설정됩니다'}
-            </div>
-          )}
-        </div>
-
-        {/* AI 초안 생성 — FREE 타입은 미지원이므로 렌더링하지 않음 */}
-        {selectedType !== 'FREE' && (
-          <div>
-            <div className="flex items-center gap-2 mb-2">
-              <p className="text-sm font-medium text-gray-700">AI 초안 생성</p>
-              <span className="bg-gray-100 text-gray-500 text-xs px-2 py-0.5 rounded-md">
-                준비 중
-              </span>
-            </div>
-            <textarea
-              placeholder="문서 초안을 어떻게 작성할지 AI에게 알려주세요... (준비 중인 기능입니다)"
-              disabled
-              className="w-full h-24 px-4 py-2.5 text-sm border border-gray-200 rounded-lg resize-none text-gray-400 placeholder-gray-300 bg-gray-50 cursor-not-allowed outline-none"
-            />
-          </div>
-        )}
 
         {/* 버튼 */}
         <div className="flex justify-end gap-2">

--- a/src/components/main/FeedbackModal.tsx
+++ b/src/components/main/FeedbackModal.tsx
@@ -6,12 +6,14 @@ interface FeedbackModalProps {
   isFeedbackModalOpen: boolean;
   toggleFeedbackModal: () => void;
   docId: string;
+  isFreeDoc?: boolean;
 }
 
 export default function FeedbackModal({
   isFeedbackModalOpen,
   toggleFeedbackModal,
   docId,
+  isFreeDoc = false,
 }: FeedbackModalProps) {
   const { requestFeedback } = useFeedback();
   const [prevOpen, setPrevOpen] = useState(isFeedbackModalOpen);
@@ -40,7 +42,11 @@ export default function FeedbackModal({
         <textarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          placeholder="선택사항입니다. 입력하지 않으면 아이디어와 비교해서 피드백을 해드립니다."
+          placeholder={
+            isFreeDoc
+              ? '어떤 방향으로 개선할지 알려주세요. 작성하지 않으면 AI가 먼저 질문을 드립니다.'
+              : '선택사항입니다. 입력하지 않으면 아이디어와 비교해서 피드백을 해드립니다.'
+          }
           className="w-full h-32 border border-gray-300 rounded-xl p-4 text-sm resize-none focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 placeholder:text-gray-400 transition-all leading-relaxed"
         ></textarea>
         <Button

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import { MdAutoAwesome } from 'react-icons/md';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
@@ -14,6 +14,7 @@ import { Helmet } from 'react-helmet-async';
 import { useTeamspaceStore } from '@/store/teamspaceStore';
 import { useTeamspaceDetail } from '@/hooks/useTeamspaceDetail';
 import { apiClient } from '@/shared/apiClient';
+import { debounce } from '@/shared/debounce';
 
 const CURSOR_COLORS = ['#1971c2', '#e03131', '#2f9e44', '#f08c00', '#7048e8'];
 
@@ -32,7 +33,14 @@ export default function MainContent() {
   const { teamspace, refetch: refetchTeamspace } = useTeamspaceDetail(currentTeamspaceId);
 
   const titleRef = useRef<HTMLHeadingElement>(null);
-  const titleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debouncedSaveTitle = useMemo(
+    () =>
+      debounce(async (id: string, title: string, onDone: () => void) => {
+        await apiClient.patch(`/api/documents/${id}`, { title });
+        onDone();
+      }, 600),
+    []
+  );
   const isAiDraftGenerating =
     docId && doc?.type !== 'FREE' ? documentAiStatuses[docId] === 'DRAFT' : false;
   const isViewer = onlineMembers.find((m) => m.userId === user?.id)?.role === 'VIEWER';
@@ -69,21 +77,15 @@ export default function MainContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [doc?.id, doc?.title]);
 
-  // docId 변경 / 언마운트 시 디바운스 타이머 정리
+  // docId 변경 / 언마운트 시 대기 중인 디바운스 취소
   useEffect(() => {
-    return () => {
-      if (titleDebounceRef.current) clearTimeout(titleDebounceRef.current);
-    };
-  }, [docId]);
+    return () => debouncedSaveTitle.cancel();
+  }, [docId, debouncedSaveTitle]);
 
   const handleTitleInput = (e: React.FormEvent<HTMLHeadingElement>) => {
     const text = e.currentTarget.textContent ?? '';
     if (docId) setDocumentTitleOverride(docId, text);
-    if (titleDebounceRef.current) clearTimeout(titleDebounceRef.current);
-    titleDebounceRef.current = setTimeout(async () => {
-      await apiClient.patch(`/api/documents/${docId}`, { title: text.trim() || '새 문서' });
-      refetchTeamspace();
-    }, 600);
+    debouncedSaveTitle(docId ?? '', text.trim() || '새 문서', refetchTeamspace);
   };
 
   const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLHeadingElement>) => {
@@ -91,10 +93,7 @@ export default function MainContent() {
   };
 
   const handleTitleBlur = async (e: React.FocusEvent<HTMLHeadingElement>) => {
-    if (titleDebounceRef.current) {
-      clearTimeout(titleDebounceRef.current);
-      titleDebounceRef.current = null;
-    }
+    debouncedSaveTitle.cancel();
     const text = (e.currentTarget.textContent ?? '').trim();
     const titleToSave = text || '새 문서';
     if (!text) e.currentTarget.textContent = '새 문서';

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 import { MdAutoAwesome } from 'react-icons/md';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
@@ -13,6 +13,7 @@ import useFeedback from '@/hooks/useFeedback';
 import { Helmet } from 'react-helmet-async';
 import { useTeamspaceStore } from '@/store/teamspaceStore';
 import { useTeamspaceDetail } from '@/hooks/useTeamspaceDetail';
+import { apiClient } from '@/shared/apiClient';
 
 const CURSOR_COLORS = ['#1971c2', '#e03131', '#2f9e44', '#f08c00', '#7048e8'];
 
@@ -26,8 +27,12 @@ export default function MainContent() {
   const isSplitView = useFeedbackStore((state) => state.isSplitView);
   const status = useFeedbackStore((state) => state.status);
   const feedbackId = useFeedbackStore((state) => state.feedbackId);
-  const { currentTeamspaceId, documentAiStatuses, onlineMembers } = useTeamspaceStore();
-  const { teamspace } = useTeamspaceDetail(currentTeamspaceId);
+  const { currentTeamspaceId, documentAiStatuses, onlineMembers, setDocumentTitleOverride } =
+    useTeamspaceStore();
+  const { teamspace, refetch: refetchTeamspace } = useTeamspaceDetail(currentTeamspaceId);
+
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const titleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isAiDraftGenerating =
     docId && doc?.type !== 'FREE' ? documentAiStatuses[docId] === 'DRAFT' : false;
   const isViewer = onlineMembers.find((m) => m.userId === user?.id)?.role === 'VIEWER';
@@ -56,6 +61,57 @@ export default function MainContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [docId]);
 
+  // FREE 문서 제목: doc이 로드되거나 docId가 바뀔 때 contentEditable DOM에 동기화
+  useEffect(() => {
+    if (doc?.type === 'FREE' && titleRef.current) {
+      titleRef.current.textContent = doc.title;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [doc?.id, doc?.title]);
+
+  // docId 변경 / 언마운트 시 디바운스 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (titleDebounceRef.current) clearTimeout(titleDebounceRef.current);
+    };
+  }, [docId]);
+
+  const handleTitleInput = (e: React.FormEvent<HTMLHeadingElement>) => {
+    const text = e.currentTarget.textContent ?? '';
+    if (docId) setDocumentTitleOverride(docId, text);
+    if (titleDebounceRef.current) clearTimeout(titleDebounceRef.current);
+    titleDebounceRef.current = setTimeout(async () => {
+      await apiClient.patch(`/api/documents/${docId}`, { title: text.trim() || '새 문서' });
+      refetchTeamspace();
+    }, 600);
+  };
+
+  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLHeadingElement>) => {
+    if (e.key === 'Enter') e.preventDefault();
+  };
+
+  const handleTitleBlur = async (e: React.FocusEvent<HTMLHeadingElement>) => {
+    if (titleDebounceRef.current) {
+      clearTimeout(titleDebounceRef.current);
+      titleDebounceRef.current = null;
+    }
+    const text = (e.currentTarget.textContent ?? '').trim();
+    const titleToSave = text || '새 문서';
+    if (!text) e.currentTarget.textContent = '새 문서';
+    if (docId) setDocumentTitleOverride(docId, titleToSave);
+    await apiClient.patch(`/api/documents/${docId}`, { title: titleToSave });
+    refetchTeamspace();
+  };
+
+  const handleTitlePaste = (e: React.ClipboardEvent<HTMLHeadingElement>) => {
+    e.preventDefault();
+    const text = e.clipboardData
+      .getData('text/plain')
+      .replace(/[\n\r]+/g, ' ')
+      .trim();
+    document.execCommand('insertText', false, text);
+  };
+
   const toggleFeedbackModal = () => {
     setIsFeedbackModalOpen((prev) => !prev);
   };
@@ -81,9 +137,22 @@ export default function MainContent() {
         className={`${isSplitView ? 'hidden' : 'block'} max-w-180 mx-auto px-24 md:px-10 sm:px-5 pt-5`}
       >
         <div className="flex items-center gap-3 pb-4">
-          <h1 className="text-[2.5rem] font-bold text-[#1a1a1a] tracking-tight leading-tight">
-            {docTitle}
-          </h1>
+          {doc.type === 'FREE' && !isViewer ? (
+            <h1
+              ref={titleRef}
+              contentEditable
+              suppressContentEditableWarning
+              onInput={handleTitleInput}
+              onKeyDown={handleTitleKeyDown}
+              onBlur={handleTitleBlur}
+              onPaste={handleTitlePaste}
+              className="text-[2.5rem] font-bold text-[#1a1a1a] tracking-tight leading-tight outline-none cursor-text"
+            />
+          ) : (
+            <h1 className="text-[2.5rem] font-bold text-[#1a1a1a] tracking-tight leading-tight">
+              {docTitle}
+            </h1>
+          )}
           {(status === 'IDLE' || status === 'ACCEPTED') && (
             <button
               onClick={toggleFeedbackModal}

--- a/src/components/main/MainContent.tsx
+++ b/src/components/main/MainContent.tsx
@@ -28,7 +28,8 @@ export default function MainContent() {
   const feedbackId = useFeedbackStore((state) => state.feedbackId);
   const { currentTeamspaceId, documentAiStatuses, onlineMembers } = useTeamspaceStore();
   const { teamspace } = useTeamspaceDetail(currentTeamspaceId);
-  const isAiDraftGenerating = docId ? documentAiStatuses[docId] === 'DRAFT' : false;
+  const isAiDraftGenerating =
+    docId && doc?.type !== 'FREE' ? documentAiStatuses[docId] === 'DRAFT' : false;
   const isViewer = onlineMembers.find((m) => m.userId === user?.id)?.role === 'VIEWER';
 
   const resetFeedback = useFeedbackStore((state) => state.resetFeedback);
@@ -68,18 +69,20 @@ export default function MainContent() {
     color: CURSOR_COLORS[(user?.id ?? 0) % CURSOR_COLORS.length],
   };
 
+  const docTitle = doc.type === 'FREE' ? doc.title : getDocLabel(doc.type);
+
   return (
     <main className="flex-1 overflow-y-auto bg-white relative">
       <Helmet>
-        <title>{`${getDocLabel(doc.type)} - ${teamspace?.name ?? 'Aidea'}`}</title>
+        <title>{`${docTitle} - ${teamspace?.name ?? 'Aidea'}`}</title>
       </Helmet>
-      {isSplitView && <SplitView title={getDocLabel(doc.type)} />}
+      {isSplitView && <SplitView title={docTitle} />}
       <div
         className={`${isSplitView ? 'hidden' : 'block'} max-w-180 mx-auto px-24 md:px-10 sm:px-5 pt-5`}
       >
         <div className="flex items-center gap-3 pb-4">
           <h1 className="text-[2.5rem] font-bold text-[#1a1a1a] tracking-tight leading-tight">
-            {getDocLabel(doc.type)}
+            {docTitle}
           </h1>
           {(status === 'IDLE' || status === 'ACCEPTED') && (
             <button
@@ -112,6 +115,7 @@ export default function MainContent() {
         isFeedbackModalOpen={isFeedbackModalOpen}
         toggleFeedbackModal={toggleFeedbackModal}
         docId={docId ?? ''}
+        isFreeDoc={doc.type === 'FREE'}
       />
 
       {status === 'FAILED' && (

--- a/src/components/main/MainSideBar.tsx
+++ b/src/components/main/MainSideBar.tsx
@@ -42,7 +42,7 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
   const navigate = useNavigate();
   const { docId } = useParams();
   const { user } = useCurrentUser();
-  const { currentTeamspaceId, documentAiStatuses } = useTeamspaceStore();
+  const { currentTeamspaceId, documentAiStatuses, documentTitleOverrides } = useTeamspaceStore();
   const { teamspace, refetch } = useTeamspaceDetail(currentTeamspaceId);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -106,7 +106,9 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
               onClick={() => navigate(`/main/${doc.id}`)}
             >
               <span className="font-semibold">
-                {doc.type === 'FREE' ? doc.title : getDocLabel(doc.type)}
+                {doc.type === 'FREE'
+                  ? (documentTitleOverrides[doc.id] ?? doc.title)
+                  : getDocLabel(doc.type)}
               </span>
               {isSideBarOpen && (
                 <span className="ml-auto flex items-center gap-1">

--- a/src/components/main/MainSideBar.tsx
+++ b/src/components/main/MainSideBar.tsx
@@ -9,6 +9,7 @@ import {
   MdCode,
   MdTableChart,
   MdAdd,
+  MdEditNote,
 } from 'react-icons/md';
 import UserAvatar from '../ui/UserAvatar';
 import Button from '../ui/Button';
@@ -29,6 +30,7 @@ const DOC_ICON: Record<DocumentType, ElementType> = {
   USER_SCENARIO: MdPerson,
   API_SPEC: MdCode,
   ERD: MdTableChart,
+  FREE: MdEditNote,
 };
 
 interface SideBarProps {
@@ -44,9 +46,13 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
   const { teamspace, refetch } = useTeamspaceDetail(currentTeamspaceId);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleCreateDocument = async (type: string) => {
+  const handleCreateDocument = async (type: string, title?: string) => {
     if (!currentTeamspaceId) return;
-    await apiClient.post('/api/documents', { teamspaceId: currentTeamspaceId, type });
+    await apiClient.post('/api/documents', {
+      teamspaceId: currentTeamspaceId,
+      type,
+      ...(title ? { title } : {}),
+    });
     refetch();
   };
 
@@ -85,7 +91,7 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
       <div className={cn('flex flex-col p-2 space-y-1', !isSideBarOpen && 'items-center')}>
         {teamspace?.documents.map((doc) => {
           const Icon = DOC_ICON[doc.type] ?? MdDescription;
-          const isDrafting = documentAiStatuses[doc.id] === 'DRAFT';
+          const isDrafting = doc.type !== 'FREE' && documentAiStatuses[doc.id] === 'DRAFT';
 
           return (
             <Button
@@ -99,7 +105,9 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
               )}
               onClick={() => navigate(`/main/${doc.id}`)}
             >
-              <span className="font-semibold">{getDocLabel(doc.type)}</span>
+              <span className="font-semibold">
+                {doc.type === 'FREE' ? doc.title : getDocLabel(doc.type)}
+              </span>
               {isSideBarOpen && (
                 <span className="ml-auto flex items-center gap-1">
                   {isDrafting && (
@@ -128,6 +136,7 @@ export default function MainSideBar({ isSideBarOpen, toggleSideBar }: SideBarPro
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onConfirm={handleCreateDocument}
+        existingDocTypes={teamspace?.documents.map((d) => d.type) ?? []}
       />
 
       {/* 하단으로 밀기 */}

--- a/src/shared/debounce.ts
+++ b/src/shared/debounce.ts
@@ -1,0 +1,23 @@
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delay: number
+): ((...args: Args) => void) & { cancel: () => void } {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  const debounced = (...args: Args): void => {
+    if (timerId !== null) clearTimeout(timerId);
+    timerId = setTimeout(() => {
+      fn(...args);
+      timerId = null;
+    }, delay);
+  };
+
+  debounced.cancel = (): void => {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  };
+
+  return debounced;
+}

--- a/src/store/teamspaceStore.ts
+++ b/src/store/teamspaceStore.ts
@@ -19,12 +19,14 @@ interface TeamspaceState {
   currentTeamspaceId: string | null;
   onlineMembers: ActiveMember[];
   documentAiStatuses: Record<string, DocumentAiStatus>;
+  documentTitleOverrides: Record<string, string>;
   pendingDraft: PendingDraft | null;
   draftQA: DraftQA | null;
   setCurrentTeamspaceId: (id: string | null) => void;
   setOnlineMembers: (members: ActiveMember[]) => void;
   setMemberRole: (userId: number, role: MemberRole) => void;
   setDocumentAiStatus: (documentId: string, aiStatus: DocumentAiStatus) => void;
+  setDocumentTitleOverride: (documentId: string, title: string) => void;
   setPendingDraft: (draft: PendingDraft | null) => void;
   setDraftQuestioning: (documentId: string, draftId: string, questions: Question[]) => void;
   setDraftAnswering: () => void;
@@ -42,6 +44,7 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
   currentTeamspaceId: null,
   onlineMembers: [],
   documentAiStatuses: {},
+  documentTitleOverrides: {},
   pendingDraft: null,
   draftQA: null,
   setCurrentTeamspaceId: (id) => set({ currentTeamspaceId: id }),
@@ -53,6 +56,10 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
   setDocumentAiStatus: (documentId, aiStatus) =>
     set((state) => ({
       documentAiStatuses: { ...state.documentAiStatuses, [documentId]: aiStatus },
+    })),
+  setDocumentTitleOverride: (documentId, title) =>
+    set((state) => ({
+      documentTitleOverrides: { ...state.documentTitleOverrides, [documentId]: title },
     })),
   setPendingDraft: (draft) => set({ pendingDraft: draft }),
   setDraftQuestioning: (documentId, draftId, questions) =>
@@ -71,5 +78,11 @@ export const useTeamspaceStore = create<TeamspaceState>()((set) => ({
     ),
   clearDraftQA: () => set({ draftQA: null }),
   clearTeamspacePresence: () =>
-    set({ onlineMembers: [], documentAiStatuses: {}, pendingDraft: null, draftQA: null }),
+    set({
+      onlineMembers: [],
+      documentAiStatuses: {},
+      documentTitleOverrides: {},
+      pendingDraft: null,
+      draftQA: null,
+    }),
 }));

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,4 +1,4 @@
-export type DocumentType = 'IDEA' | 'PLAN' | 'USER_SCENARIO' | 'API_SPEC' | 'ERD';
+export type DocumentType = 'IDEA' | 'PLAN' | 'USER_SCENARIO' | 'API_SPEC' | 'ERD' | 'FREE';
 export type FeedbackStatus =
   | 'IDLE'
   | 'PENDING'


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

- Closes #80

<br>

## 📝 작업 내용

기획 문서 외 자유롭게 작성할 수 있는 FREE(자유 문서) 타입을 추가했습니다.
자유 문서는 AI 초안 없이 여러 개 생성 가능하며, 생성 시 제목을 직접 입력합니다.
에디터 상단에서 제목을 인라인 편집할 수 있고, 사이드바에 실시간으로 반영됩니다.

주요 변경 사항:
- DocumentType에 FREE 추가, DOC_OPTIONS에 자유 문서 선택지 노출
- CreateDocumentModal: 기존 타입은 이미 존재하면 비활성화, FREE는 여러 개 생성 가능, 생성 시 제목 입력 필수, AI 초안 섹션 숨김
- 새 문서 추가 시 자유 문서가 기본 선택값으로 설정
- MainSideBar: FREE 아이콘 등록, 문서 레이블을 doc.title로 표시, isDrafting에서 FREE 명시적 제외, title을 API에 함께 전달
- MainContent: isAiDraftGenerating에서 FREE 명시적 제외, h1/SplitView/Helmet 제목을 doc.title로 표시
- FREE 문서 h1 인라인 편집 기능: 타이핑마다 600ms 디바운스 후 PATCH, blur 시 즉시 저장, Enter/붙여넣기 제어
- teamspaceStore에 documentTitleOverrides 맵 추가해 타이핑 즉시 사이드바 제목 실시간 갱신
- 디바운스 로직을 유틸 함수로 분리
- FeedbackModal: FREE 문서 전용 additionalRequest 안내 문구 적용
- 팀스페이스 생성 단계에서는 자유 문서 생성 불가 처리

<br>


## 🖼️ 스크린샷 (선택)

<img width="1912" height="860" alt="image" src="https://github.com/user-attachments/assets/c5eda75b-6445-468b-b856-364e239eebd3" />


<br>

## 테스트 및 검증 내용

- 문서 추가 모달에서 자유 문서 선택 후 제목 입력 및 생성이 정상 동작하는지 확인
- 자유 문서를 여러 개 생성할 수 있는지 확인
- 에디터 상단 h1 제목 편집 시 사이드바 레이블이 즉시 갱신되는지 확인
- 600ms 디바운스 후 PATCH API가 호출되고, blur 시 즉시 저장되는지 확인
- 팀스페이스 생성 단계에서 자유 문서 옵션이 비활성화되는지 확인

<br>

## 🤔 주요 고민과 해결 과정

**[제목 편집 UX: API 호출 빈도 vs 즉각적인 UI 반응]**

h1을 contentEditable로 두면 매 keystroke마다 PATCH 요청이 발생할 수 있음.
600ms 디바운스를 적용해 API 호출 빈도를 줄이되, 로컬 상태(documentTitleOverrides)에는
타이핑 즉시 반영해 사이드바 UI가 끊김 없이 갱신되도록 처리. blur 시에는 디바운스 대기 없이
즉시 저장해 페이지 이탈 시 데이터 유실을 방지.
